### PR TITLE
Fix missing import in main app

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, render_template, jsonify
+from flask import Flask, render_template, jsonify, send_from_directory
 from flask_cors import CORS
 from sqlalchemy import text
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix missing `send_from_directory` import

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d4596001c832ca3f1a94b3119f787