### PR TITLE
Fix DB initialization missing columns

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -27,6 +27,7 @@ from src.models.os_peca import OS_Peca
 from src.models.analise_oleo import AnaliseOleo
 
 from datetime import datetime, date, timedelta
+from sqlalchemy import text, inspect
 
 def create_app():
     """Criar aplicação Flask para inicialização."""
@@ -64,8 +65,46 @@ def create_app():
     
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     db.init_app(app)
-    
+
     return app
+
+def ensure_schema():
+    """Garantir que as colunas necessárias existam no banco."""
+    engine = db.engine
+    inspector = inspect(engine)
+
+    # Verificar coluna tipo_equipamento_id em equipamentos
+    cols = [c['name'] for c in inspector.get_columns('equipamentos')]
+    if 'tipo_equipamento_id' not in cols:
+        print("⚙️  Adicionando coluna 'tipo_equipamento_id' em equipamentos...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE equipamentos ADD COLUMN tipo_equipamento_id INTEGER'))
+            conn.commit()
+
+    # Verificar coluna tipo_manutencao_id em ordens_servico
+    cols = [c['name'] for c in inspector.get_columns('ordens_servico')]
+    if 'tipo_manutencao_id' not in cols:
+        print("⚙️  Adicionando coluna 'tipo_manutencao_id' em ordens_servico...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE ordens_servico ADD COLUMN tipo_manutencao_id INTEGER'))
+            conn.commit()
+
+    # Verificar colunas grupo_item_id e estoque_local_id em pecas
+    cols = [c['name'] for c in inspector.get_columns('pecas')]
+    if 'grupo_item_id' not in cols:
+        print("⚙️  Adicionando coluna 'grupo_item_id' em pecas...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE pecas ADD COLUMN grupo_item_id INTEGER'))
+            conn.commit()
+    if 'estoque_local_id' not in cols:
+        print("⚙️  Adicionando coluna 'estoque_local_id' em pecas...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE pecas ADD COLUMN estoque_local_id INTEGER'))
+            conn.commit()
 
 def criar_dados_exemplo():
     """Função para criar dados de exemplo no banco"""
@@ -394,9 +433,11 @@ def main():
         with app.app_context():
             print("🔧 Criando/verificando estrutura do banco de dados...")
             db.create_all()
-            
+            ensure_schema()
+
             print("📊 Populando com dados de exemplo...")
-            criar_dados_exemplo()
+            # Usar a função mais completa para garantir compatibilidade
+            criar_dados_exemplo_completos()
             
             print("\n" + "=" * 60)
             print("✅ SISTEMA INICIALIZADO COM SUCESSO!")
@@ -625,5 +666,7 @@ def criar_dados_exemplo_completos():
 # Manter compatibilidade com a função original
 def criar_dados_exemplo():
     """Função de compatibilidade - chama a função completa"""
+    # Garante que colunas novas existam mesmo quando chamado fora do main()
+    ensure_schema()
     return criar_dados_exemplo_completos()
 


### PR DESCRIPTION
## Summary
- add schema check to add missing columns during initialization
- call `ensure_schema` when creating example data so other scripts also update schema
- ensure the CLI initialization uses `criar_dados_exemplo_completos`

## Testing
- `python -m py_compile init_db.py src/models/equipamento.py src/models/ordem_servico.py src/models/peca.py`


------
https://chatgpt.com/codex/tasks/task_e_688d4f13a658832cb66a5a9a4d8cb115