### PR TITLE
Fix missing signature column

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -73,6 +73,15 @@ def ensure_schema():
                 'ALTER TABLE ordens_servico ADD COLUMN tipo_manutencao_id INTEGER'))
             conn.commit()
 
+    # Verificar coluna assinatura_responsavel em ordens_servico
+    cols = [c['name'] for c in inspector.get_columns('ordens_servico')]
+    if 'assinatura_responsavel' not in cols:
+        print("⚙️  Adicionando coluna 'assinatura_responsavel' em ordens_servico...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE ordens_servico ADD COLUMN assinatura_responsavel TEXT'))
+            conn.commit()
+
     # Verificar colunas grupo_item_id e estoque_local_id em pecas
     cols = [c['name'] for c in inspector.get_columns('pecas')]
     if 'grupo_item_id' not in cols:


### PR DESCRIPTION
## Summary
- ensure `assinatura_responsavel` column is created when initializing the DB

## Testing
- `python - <<'PY'
import os
from init_db import create_app, ensure_schema
app = create_app()
with app.app_context():
    ensure_schema()
    print("done")
PY`

------
https://chatgpt.com/codex/tasks/task_e_688d64e643bc832c87d2266a82bd5d2e