### PR TITLE
Handle missing inventory columns for pecas

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -108,6 +108,18 @@ def ensure_schema():
             conn.execute(text(
                 'ALTER TABLE pecas ADD COLUMN ultimo_preco_compra FLOAT'))
             conn.commit()
+    if 'ultima_inventariacao_data' not in cols:
+        print("⚙️  Adicionando coluna 'ultima_inventariacao_data' em pecas...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                'ALTER TABLE pecas ADD COLUMN ultima_inventariacao_data TIMESTAMP'))
+            conn.commit()
+    if 'ultima_inventariacao_usuario' not in cols:
+        print("⚙️  Adicionando coluna 'ultima_inventariacao_usuario' em pecas...")
+        with engine.connect() as conn:
+            conn.execute(text(
+                "ALTER TABLE pecas ADD COLUMN ultima_inventariacao_usuario VARCHAR(100)"))
+            conn.commit()
 
 def criar_dados_exemplo():
     """Função para criar dados de exemplo no banco"""


### PR DESCRIPTION
## Summary
- ensure new inventory tracking columns are added when initializing schema

## Testing
- `python -m py_compile init_db.py`
- `python - <<'PY'
import os
os.environ['DATABASE_URL']='sqlite:///temp2.db'
import init_db
app = init_db.create_app()
with app.app_context():
    init_db.db.create_all()
    init_db.ensure_schema()
    from sqlalchemy import inspect
    inspector = inspect(init_db.db.engine)
    cols = [c['name'] for c in inspector.get_columns('pecas')]
    print('pecas columns:', cols)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688d7cf16270832ca2413462495618bb