### PR TITLE
Use email for login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ railway up
 
 ## 👥 Usuários Padrão
 
-O sistema cria automaticamente os seguintes usuários para teste:
+O sistema cria automaticamente os seguintes usuários para teste (utilize o e-mail para login):
 
-| Usuário | Senha | Nível |
-|---------|-------|-------|
-| admin | admin123 | Administrador |
-| supervisor | super123 | Supervisor |
-| pcm | pcm123 | PCM |
-| almoxarife | almox123 | Almoxarife |
-| mecanico | mec123 | Mecânico |
+| E-mail | Senha | Nível |
+|--------|-------|-------|
+| admin@mineracao.com | admin123 | Administrador |
+| supervisor@mineracao.com | super123 | Supervisor |
+| pcm@mineracao.com | pcm123 | PCM |
+| almoxarife@mineracao.com | almox123 | Almoxarife |
+| mecanico@mineracao.com | mec123 | Mecânico |
 
 ## 📊 Estrutura do Banco de Dados
 

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -14,12 +14,16 @@ def login():
     try:
         data = request.get_json()
         email = data.get('email')
+        username = data.get('username')
         senha = data.get('senha')
 
-        if not email or not senha:
-            return jsonify({'error': 'Email e senha são obrigatórios'}), 400
+        if not senha or not (email or username):
+            return jsonify({'error': 'Email/usuário e senha são obrigatórios'}), 400
 
-        usuario = Usuario.query.filter_by(email=email).first()
+        if email:
+            usuario = Usuario.query.filter_by(email=email).first()
+        else:
+            usuario = Usuario.query.filter_by(username=username).first()
         if not usuario or not usuario.check_password(senha):
             return jsonify({'error': 'Credenciais inválidas'}), 401
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -27,10 +27,10 @@
             
             <form id="login-form" class="login-form">
                 <div class="form-group">
-                    <label for="username">Usuário</label>
+                    <label for="email">E-mail</label>
                     <div class="input-group">
                         <i class="fas fa-user"></i>
-                        <input type="text" id="username" name="username" required>
+                        <input type="email" id="email" name="email" required>
                     </div>
                 </div>
                 

--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -122,6 +122,7 @@ const api = new ApiClient();
 const API = {
     // Autenticação
     auth: {
+        // Encaminha os campos exatamente como recebidos
         login: (credentials) => api.post('/auth/login', credentials),
         logout: () => api.post('/auth/logout'),
         me: () => api.get('/auth/me')

--- a/src/static/js/auth.js
+++ b/src/static/js/auth.js
@@ -136,7 +136,7 @@ const auth = new AuthManager();
 class LoginForm {
     constructor() {
         this.form = null;
-        this.usernameInput = null;
+        this.emailInput = null;
         this.passwordInput = null;
         this.submitButton = null;
         this.errorDiv = null;
@@ -156,7 +156,7 @@ class LoginForm {
 
     setupForm() {
         this.form = document.getElementById('login-form');
-        this.usernameInput = document.getElementById('username');
+        this.emailInput = document.getElementById('email');
         this.passwordInput = document.getElementById('password');
         this.submitButton = this.form?.querySelector('button[type="submit"]');
         this.errorDiv = document.getElementById('login-error');
@@ -171,19 +171,19 @@ class LoginForm {
             this.togglePasswordButton.addEventListener('click', () => this.togglePassword());
         }
 
-        // Auto-focus no campo de usuário
-        if (this.usernameInput) {
-            this.usernameInput.focus();
+        // Auto-focus no campo de email
+        if (this.emailInput) {
+            this.emailInput.focus();
         }
     }
 
     async handleSubmit(e) {
         e.preventDefault();
-        
-        const username = this.usernameInput?.value.trim();
-        const password = this.passwordInput?.value;
 
-        if (!username || !password) {
+        const email = this.emailInput?.value.trim();
+        const senha = this.passwordInput?.value;
+
+        if (!email || !senha) {
             this.showError('Por favor, preencha todos os campos.');
             return;
         }
@@ -191,7 +191,7 @@ class LoginForm {
         this.setLoading(true);
         this.hideError();
 
-        const result = await auth.login({ username, password });
+        const result = await auth.login({ email, senha });
 
         if (result.success) {
             // Login bem-sucedido - a aplicação será carregada pelos callbacks


### PR DESCRIPTION
## Summary
- Update login form to send `email` and `senha` to the API
- Forward auth credentials unchanged and allow backend login via email or username
- Document default accounts with their emails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d8ab067dc832cb8a369df0436d199