### PR TITLE
Add placeholder pages for missing sections

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -229,6 +229,7 @@
     <script src="js/pages/tipos-equipamento.js"></script>
     <script src="js/pages/tipos-manutencao.js"></script>
     <script src="js/pages/grupos-item.js"></script>
+    <script src="js/pages/movimentacoes.js"></script>
     <script src="js/pages/analise-oleo.js"></script>
     <script src="js/pages/importacao.js"></script>
     <script src="js/app.js"></script>

--- a/src/static/js/pages/analise-oleo.js
+++ b/src/static/js/pages/analise-oleo.js
@@ -1,0 +1,11 @@
+// Página de Análise de Óleo (placeholder)
+class OilAnalysisPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Análise de Óleo</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -1,0 +1,11 @@
+// Página de Equipamentos (placeholder)
+class EquipmentsPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Equipamentos</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -1,0 +1,11 @@
+// Página de Estoque (placeholder)
+class InventoryPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Estoque</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/grupos-item.js
+++ b/src/static/js/pages/grupos-item.js
@@ -1,0 +1,11 @@
+// Página de Grupos de Item (placeholder)
+class ItemGroupsPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Grupos de Item</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/importacao.js
+++ b/src/static/js/pages/importacao.js
@@ -1,0 +1,11 @@
+// Página de Importação de Peças (placeholder)
+class ImportPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Importar Peças</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/mecanicos.js
+++ b/src/static/js/pages/mecanicos.js
@@ -1,0 +1,11 @@
+// Página de Mecânicos (placeholder)
+class MechanicsPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Mecânicos</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/movimentacoes.js
+++ b/src/static/js/pages/movimentacoes.js
@@ -1,0 +1,11 @@
+// Página de Movimentações de Estoque (placeholder)
+class MovementsPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Movimentações de Estoque</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -1,0 +1,11 @@
+// Página de Ordens de Serviço (placeholder)
+class WorkOrdersPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Ordens de Serviço</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -1,0 +1,11 @@
+// Página de Pneus (placeholder)
+class TiresPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Pneus</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/tipos-equipamento.js
+++ b/src/static/js/pages/tipos-equipamento.js
@@ -1,0 +1,11 @@
+// Página de Tipos de Equipamento (placeholder)
+class EquipmentTypesPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Tipos de Equipamento</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/tipos-manutencao.js
+++ b/src/static/js/pages/tipos-manutencao.js
@@ -1,0 +1,11 @@
+// Página de Tipos de Manutenção (placeholder)
+class MaintenanceTypesPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Tipos de Manutenção</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}

--- a/src/static/js/pages/usuarios.js
+++ b/src/static/js/pages/usuarios.js
@@ -1,0 +1,11 @@
+// Página de Usuários (placeholder)
+class UsersPage {
+    async render(container) {
+        container.innerHTML = `
+            <div class="page-placeholder">
+                <h1>Usuários</h1>
+                <p>Página em desenvolvimento.</p>
+            </div>
+        `;
+    }
+}


### PR DESCRIPTION
## Summary
- create placeholder JS pages for work orders, equipment, inventory, and other sections
- include movement page script in index.html so navigation can load it

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `for f in src/static/js/pages/*.js; do node --check "$f"; done`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688d8edd6a40832c9d451cb09cda748f