### PR TITLE
Fix login flow and restyle login page

### DIFF
--- a/src/static/js/auth.js
+++ b/src/static/js/auth.js
@@ -21,17 +21,24 @@ class AuthManager {
     async login(credentials) {
         try {
             const response = await API.auth.login(credentials);
-            
-            if (response.token) {
-                this.token = response.token;
-                this.currentUser = response.user;
-                
-                // Salvar token
+
+            // Depuração da resposta recebida
+            console.log('login response', response);
+
+            // Alguns backends retornam dados aninhados em `data`
+            const token = response.token || response.data?.token;
+            const user = response.user || response.data?.user;
+
+            if (token) {
+                this.token = token;
+                this.currentUser = user;
+
+                // Salvar token localmente para persistência
                 api.setToken(this.token);
-                
-                // Executar callbacks de login
+
+                // Executar callbacks de login registrados
                 this.loginCallbacks.forEach(callback => callback(this.currentUser));
-                
+
                 return { success: true, user: this.currentUser };
             } else {
                 throw new Error('Token não recebido');
@@ -196,6 +203,11 @@ class LoginForm {
         if (result.success) {
             // Login bem-sucedido - a aplicação será carregada pelos callbacks
             this.showSuccess('Login realizado com sucesso!');
+
+            // Redirecionar/inicializar app após breve atraso
+            setTimeout(() => {
+                window.location.reload();
+            }, 800);
         } else {
             this.showError(result.error || 'Erro ao fazer login. Verifique suas credenciais.');
         }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -115,12 +115,14 @@ body {
 }
 
 .login-container {
-    background: white;
+    background: rgba(255, 255, 255, 0.9);
     border-radius: var(--radius-xl);
     padding: 2rem;
     width: 100%;
     max-width: 400px;
     box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(4px);
+    border: 1px solid var(--gray-100);
 }
 
 .login-header {
@@ -210,10 +212,12 @@ body {
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+    box-shadow: var(--shadow);
 }
 
 .login-btn:hover {
     background: var(--primary-dark);
+    box-shadow: var(--shadow-md);
 }
 
 .login-btn:disabled {


### PR DESCRIPTION
## Summary
- improve AuthManager login to log responses and persist tokens reliably
- reload application after successful login
- polish login container and button visuals

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_688d909bb9e0832cb7fcea0484e0b7c7