### PR TITLE
feat: add current user endpoint

### DIFF
--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -65,6 +65,7 @@ def logout(current_user):
     return jsonify({'message': 'Logout realizado com sucesso'}), 200
 
 @auth_bp.route('/auth/profile', methods=['GET'])
+@auth_bp.route('/auth/me', methods=['GET'])
 @token_required
 def get_profile(current_user):
     """Obter perfil do usuário atual"""


### PR DESCRIPTION
## Summary
- add `/auth/me` endpoint so frontend can verify current session

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d93f66d3c832c99251dbb2f47a886