### PR TITLE
Expose page classes globally

### DIFF
--- a/src/static/js/pages/analise-oleo.js
+++ b/src/static/js/pages/analise-oleo.js
@@ -9,3 +9,5 @@ class OilAnalysisPage {
         `;
     }
 }
+
+window.OilAnalysisPage = OilAnalysisPage;

--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -9,3 +9,5 @@ class EquipmentsPage {
         `;
     }
 }
+
+window.EquipmentsPage = EquipmentsPage;

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -9,3 +9,5 @@ class InventoryPage {
         `;
     }
 }
+
+window.InventoryPage = InventoryPage;

--- a/src/static/js/pages/grupos-item.js
+++ b/src/static/js/pages/grupos-item.js
@@ -9,3 +9,5 @@ class ItemGroupsPage {
         `;
     }
 }
+
+window.ItemGroupsPage = ItemGroupsPage;

--- a/src/static/js/pages/importacao.js
+++ b/src/static/js/pages/importacao.js
@@ -9,3 +9,5 @@ class ImportPage {
         `;
     }
 }
+
+window.ImportPage = ImportPage;

--- a/src/static/js/pages/mecanicos.js
+++ b/src/static/js/pages/mecanicos.js
@@ -9,3 +9,5 @@ class MechanicsPage {
         `;
     }
 }
+
+window.MechanicsPage = MechanicsPage;

--- a/src/static/js/pages/movimentacoes.js
+++ b/src/static/js/pages/movimentacoes.js
@@ -9,3 +9,5 @@ class MovementsPage {
         `;
     }
 }
+
+window.MovementsPage = MovementsPage;

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -9,3 +9,5 @@ class WorkOrdersPage {
         `;
     }
 }
+
+window.WorkOrdersPage = WorkOrdersPage;

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -9,3 +9,5 @@ class TiresPage {
         `;
     }
 }
+
+window.TiresPage = TiresPage;

--- a/src/static/js/pages/tipos-equipamento.js
+++ b/src/static/js/pages/tipos-equipamento.js
@@ -9,3 +9,5 @@ class EquipmentTypesPage {
         `;
     }
 }
+
+window.EquipmentTypesPage = EquipmentTypesPage;

--- a/src/static/js/pages/tipos-manutencao.js
+++ b/src/static/js/pages/tipos-manutencao.js
@@ -9,3 +9,5 @@ class MaintenanceTypesPage {
         `;
     }
 }
+
+window.MaintenanceTypesPage = MaintenanceTypesPage;

--- a/src/static/js/pages/usuarios.js
+++ b/src/static/js/pages/usuarios.js
@@ -9,3 +9,5 @@ class UsersPage {
         `;
     }
 }
+
+window.UsersPage = UsersPage;


### PR DESCRIPTION
## Summary
- Register all page classes on the `window` object so the navigation router can locate them at runtime.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d96b1bf4c832c921c4e9453f2e639