### PR TITLE
Fix WorkOrdersPage export and add form autocomplete

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -30,7 +30,7 @@
                     <label for="email">E-mail</label>
                     <div class="input-group">
                         <i class="fas fa-user"></i>
-                        <input type="email" id="email" name="email" required>
+                        <input type="email" id="email" name="email" autocomplete="username" required>
                     </div>
                 </div>
                 
@@ -38,7 +38,7 @@
                     <label for="password">Senha</label>
                     <div class="input-group">
                         <i class="fas fa-lock"></i>
-                        <input type="password" id="password" name="password" required>
+                        <input type="password" id="password" name="password" autocomplete="current-password" required>
                         <button type="button" class="toggle-password">
                             <i class="fas fa-eye"></i>
                         </button>

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -750,9 +750,7 @@ class WorkOrdersPage {
         Toast.error(err.message || 'Erro ao preparar modal.');
     }
 }
+}
 
-/// Instância global para uso nos event handlers
-//const workOrdersPage = new WorkOrdersPage();
-
-// Exportar para uso global
-//window.WorkOrdersPage = WorkOrdersPage;
+// Exportar a classe para uso global
+window.WorkOrdersPage = WorkOrdersPage;


### PR DESCRIPTION
## Summary
- close WorkOrdersPage class and export globally to fix navigation
- add autocomplete attributes to login form fields

## Testing
- `node --check src/static/js/pages/ordens-servico.js && echo 'Syntax OK'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890c6327b80832ca7c6968cfe73af17