### PR TITLE
Centralize SQLAlchemy instance across app

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -8,7 +8,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, current_dir)
 
 from flask import Flask
-from src.models.usuario import db
+from src.db import db
 
 # Importar todos os modelos para que sejam registrados
 from src.models.equipamento import Equipamento

--- a/init_db.py
+++ b/init_db.py
@@ -12,7 +12,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, current_dir)
 
 from flask import Flask
-from src.models.usuario import db, Usuario
+from src.db import db
+from src.models.usuario import Usuario
 from src.models.equipamento import Equipamento
 from src.models.mecanico import Mecanico
 from src.models.ordem_servico import OrdemServico

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,6 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Central SQLAlchemy database instance
+# This module provides a single shared instance of SQLAlchemy
+# to be imported across the application.
+db = SQLAlchemy()

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 # Importar modelos
-from src.models.usuario import db
+from src.db import db
 
 # Importar blueprints
 from src.routes.auth import auth_bp

--- a/src/models/analise_oleo.py
+++ b/src/models/analise_oleo.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 import json
 

--- a/src/models/equipamento.py
+++ b/src/models/equipamento.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime, date
 
 class Equipamento(db.Model):

--- a/src/models/estoque_local.py
+++ b/src/models/estoque_local.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class EstoqueLocal(db.Model):

--- a/src/models/grupo_item.py
+++ b/src/models/grupo_item.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class GrupoItem(db.Model):

--- a/src/models/mecanico.py
+++ b/src/models/mecanico.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime, date
 
 class Mecanico(db.Model):

--- a/src/models/movimentacao_estoque.py
+++ b/src/models/movimentacao_estoque.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class MovimentacaoEstoque(db.Model):

--- a/src/models/ordem_servico.py
+++ b/src/models/ordem_servico.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class OrdemServico(db.Model):

--- a/src/models/os_peca.py
+++ b/src/models/os_peca.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class OS_Peca(db.Model):

--- a/src/models/peca.py
+++ b/src/models/peca.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class Peca(db.Model):

--- a/src/models/pneu.py
+++ b/src/models/pneu.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime, date
 
 class Pneu(db.Model):

--- a/src/models/tipo_equipamento.py
+++ b/src/models/tipo_equipamento.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class TipoEquipamento(db.Model):

--- a/src/models/tipo_manutencao.py
+++ b/src/models/tipo_manutencao.py
@@ -1,4 +1,4 @@
-from src.models.usuario import db
+from src.db import db
 from datetime import datetime
 
 class TipoManutencao(db.Model):

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,6 +1,4 @@
-from flask_sqlalchemy import SQLAlchemy
-
-db = SQLAlchemy()
+from src.db import db
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/src/models/usuario.py
+++ b/src/models/usuario.py
@@ -1,8 +1,7 @@
-from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
 
-db = SQLAlchemy()
+from src.db import db
 
 class Usuario(db.Model):
     __tablename__ = 'usuarios'

--- a/src/routes/analise_oleo.py
+++ b/src/routes/analise_oleo.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.analise_oleo import AnaliseOleo
 from src.models.equipamento import Equipamento
 from src.utils.auth import token_required, pcm_or_above_required

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, jsonify
 from werkzeug.security import check_password_hash
-from src.models.usuario import Usuario, db
+from src.db import db
+from src.models.usuario import Usuario
 from src.utils.auth import token_required, get_user_permissions
 import jwt
 from datetime import datetime, timedelta

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.equipamento import Equipamento
 from src.models.ordem_servico import OrdemServico
 from src.models.peca import Peca

--- a/src/routes/equipamentos.py
+++ b/src/routes/equipamentos.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.equipamento import Equipamento
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime

--- a/src/routes/estoque.py
+++ b/src/routes/estoque.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.peca import Peca
 from src.models.movimentacao_estoque import MovimentacaoEstoque
 from src.models.estoque_local import EstoqueLocal

--- a/src/routes/grupos_item.py
+++ b/src/routes/grupos_item.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.grupo_item import GrupoItem
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime

--- a/src/routes/importacao.py
+++ b/src/routes/importacao.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.peca import Peca
 from src.models.grupo_item import GrupoItem
 from src.models.estoque_local import EstoqueLocal

--- a/src/routes/impressao.py
+++ b/src/routes/impressao.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify, make_response
-from src.models.usuario import db
+from src.db import db
 from src.models.ordem_servico import OrdemServico
 from src.models.equipamento import Equipamento
 from src.models.mecanico import Mecanico

--- a/src/routes/mecanicos.py
+++ b/src/routes/mecanicos.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.mecanico import Mecanico
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime

--- a/src/routes/ordens_servico.py
+++ b/src/routes/ordens_servico.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.ordem_servico import OrdemServico
 from src.models.equipamento import Equipamento
 from src.models.mecanico import Mecanico

--- a/src/routes/pneus.py
+++ b/src/routes/pneus.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.pneu import Pneu
 from src.models.equipamento import Equipamento
 from src.utils.auth import token_required, supervisor_or_admin_required

--- a/src/routes/tipos_equipamento.py
+++ b/src/routes/tipos_equipamento.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.tipo_equipamento import TipoEquipamento
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime

--- a/src/routes/tipos_manutencao.py
+++ b/src/routes/tipos_manutencao.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import db
+from src.db import db
 from src.models.tipo_manutencao import TipoManutencao
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
-from src.models.usuario import Usuario, db
+from src.db import db
+from src.models.usuario import Usuario
 from src.utils.auth import token_required, admin_required
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- add dedicated `src/db.py` module with shared SQLAlchemy instance
- update models, routes, and scripts to import `db` from the new module
- initialize the database in `main.py` via `db.init_app(app)`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6890c978bf2c832c909b60a4c689c9ef