### PR TITLE
feat: allow creating and editing work orders

### DIFF
--- a/src/routes/ordens_servico.py
+++ b/src/routes/ordens_servico.py
@@ -261,6 +261,8 @@ def update_ordem_servico(current_user, os_id):
         data = request.get_json()
         
         # Atualizar campos permitidos
+        if 'equipamento_id' in data:
+            os.equipamento_id = data['equipamento_id']
         if 'mecanico_id' in data:
             os.mecanico_id = data['mecanico_id']
         if 'tipo' in data:

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -23,6 +23,9 @@ class WorkOrdersPage {
             // Configurar eventos
             this.setupEvents(container);
 
+            // Disponibilizar instância global para handlers inline
+            window.workOrdersPage = this;
+
             // Aplicar filtros iniciais
             this.applyFilters();
 
@@ -679,7 +682,7 @@ class WorkOrdersPage {
             </form>
         `;
         overlay.appendChild(modal);
-        document.getElementById('modals-container').appendChild(overlay);
+        (document.getElementById('modals-container') || document.body).appendChild(overlay);
 
         // Estilos (ou mova para CSS)
         if (!document.getElementById('workorder-modal-style')) {
@@ -750,6 +753,104 @@ class WorkOrdersPage {
         Toast.error(err.message || 'Erro ao preparar modal.');
     }
 }
+
+    async editWorkOrder(id) {
+        try {
+            // Carregar dados necessários em paralelo
+            const [osResponse, equipResponse, maintenanceTypes, mechanicsResponse] = await Promise.all([
+                API.workOrders.get(id),
+                API.equipments.getAll(),
+                API.maintenanceTypes.getAll(),
+                API.mechanics.getAll()
+            ]);
+
+            const os = osResponse.data || osResponse;
+            const equipments = equipResponse.data || equipResponse || [];
+            const types = maintenanceTypes.data || maintenanceTypes || [];
+            const mechanics = mechanicsResponse.data || mechanicsResponse || [];
+
+            const overlay = document.createElement('div');
+            overlay.className = 'custom-modal-overlay';
+            const modal = document.createElement('div');
+            modal.className = 'custom-modal';
+            modal.innerHTML = `
+                <h2>Editar Ordem de Serviço</h2>
+                <form id="editWorkOrderForm">
+                    <label>Equipamento*</label>
+                    <select name="equipamento_id" required>
+                        <option value="">Selecione...</option>
+                        ${equipments.map(e => `<option value="${e.id}" ${e.id === os.equipamento_id ? 'selected' : ''}>${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
+                    </select>
+
+                    <label>Tipo de Manutenção*</label>
+                    <select name="tipo" required>
+                        <option value="">Selecione...</option>
+                        ${types.map(t => `<option value="${t.id}" ${t.id === (os.tipo_manutencao_id || os.tipo) ? 'selected' : ''}>${t.nome}</option>`).join('')}
+                    </select>
+
+                    <label>Prioridade*</label>
+                    <select name="prioridade" required>
+                        <option value="">Selecione...</option>
+                        <option value="baixa" ${os.prioridade === 'baixa' ? 'selected' : ''}>Baixa</option>
+                        <option value="media" ${os.prioridade === 'media' ? 'selected' : ''}>Média</option>
+                        <option value="alta" ${os.prioridade === 'alta' ? 'selected' : ''}>Alta</option>
+                        <option value="critica" ${os.prioridade === 'critica' ? 'selected' : ''}>Crítica</option>
+                    </select>
+
+                    <label>Mecânico (opcional)</label>
+                    <select name="mecanico_id">
+                        <option value="">Nenhum</option>
+                        ${mechanics.map(m => `<option value="${m.id}" ${m.id === os.mecanico_id ? 'selected' : ''}>${m.nome_completo || m.nome}</option>`).join('')}
+                    </select>
+
+                    <label>Data Prevista</label>
+                    <input type="datetime-local" name="data_prevista" value="${os.data_prevista ? new Date(os.data_prevista).toISOString().slice(0,16) : ''}" />
+
+                    <label>Descrição do Problema*</label>
+                    <textarea name="descricao_problema" rows="3" required>${os.descricao_problema || ''}</textarea>
+
+                    <label>Observações</label>
+                    <textarea name="observacoes" rows="2">${os.observacoes || ''}</textarea>
+
+                    <div class="form-actions">
+                        <button type="submit">Salvar</button>
+                        <button type="button" id="cancelEditWorkOrder">Cancelar</button>
+                    </div>
+                </form>
+            `;
+
+            overlay.appendChild(modal);
+            (document.getElementById('modals-container') || document.body).appendChild(overlay);
+
+            modal.querySelector('#cancelEditWorkOrder').addEventListener('click', () => overlay.remove());
+
+            modal.querySelector('#editWorkOrderForm').addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const formData = new FormData(e.target);
+                const payload = {
+                    equipamento_id: parseInt(formData.get('equipamento_id')),
+                    tipo: formData.get('tipo'),
+                    prioridade: formData.get('prioridade'),
+                    mecanico_id: formData.get('mecanico_id') ? parseInt(formData.get('mecanico_id')) : null,
+                    data_prevista: formData.get('data_prevista') ? new Date(formData.get('data_prevista')).toISOString().slice(0,19).replace('T',' ') : null,
+                    descricao_problema: formData.get('descricao_problema'),
+                    observacoes: formData.get('observacoes') || null
+                };
+                try {
+                    await API.workOrders.update(id, payload);
+                    Toast.success('Ordem de serviço atualizada com sucesso!');
+                    overlay.remove();
+                    await this.refresh();
+                } catch (error) {
+                    console.error(error);
+                    Toast.error(error.message || 'Erro ao atualizar OS.');
+                }
+            });
+        } catch (err) {
+            console.error('Erro ao preparar modal de edição:', err);
+            Toast.error(err.message || 'Erro ao preparar modal.');
+        }
+    }
 }
 
 // Exportar a classe para uso global


### PR DESCRIPTION
## Summary
- expose WorkOrdersPage instance to inline handlers
- add modal helpers to create or edit work orders
- enable updating equipment on work order API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d68811f4832cab6ad69845a94622