### PR TITLE
Use ordens_servico field when loading work orders

### DIFF
--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -38,7 +38,7 @@ class WorkOrdersPage {
     async loadData() {
         try {
             const response = await API.workOrders.getAll();
-            this.data = Array.isArray(response) ? response : (response.data || []);
+            this.data = Array.isArray(response) ? response : (response.ordens_servico || []);
             this.filteredData = [...this.data];
         } catch (error) {
             console.error('Erro ao carregar dados:', error);


### PR DESCRIPTION
## Summary
- Ensure work order data reads from `response.ordens_servico`
- Keep filtered data synced with latest dataset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e39070ac832caecda977eac2c09a