### PR TITLE
Padroniza botões de formulário e centraliza estilo de ações

### DIFF
--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -798,8 +798,8 @@ class EquipmentsPage {
                     <textarea name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelEquipment">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelEquipment" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -814,7 +814,6 @@ class EquipmentsPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -878,7 +877,7 @@ class EquipmentsPage {
                     ${eq.valor_aquisicao ? `<p><strong>Valor Aquisição:</strong> R$ ${Utils.formatCurrency(eq.valor_aquisicao)}</p>` : ''}
                     ${eq.observacoes ? `<p><strong>Observações:</strong> ${eq.observacoes}</p>` : ''}
                 </div>
-                <div class="form-actions"><button id="closeDetails">Fechar</button></div>
+                <div class="form-actions"><button id="closeDetails" class="btn btn-secondary">Fechar</button></div>
             `;
 
             overlay.appendChild(modal);
@@ -892,7 +891,6 @@ class EquipmentsPage {
                 style.textContent = `
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;margin-top:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -953,8 +951,8 @@ class EquipmentsPage {
                     <textarea name="observacoes" rows="2">${eq.observacoes || ''}</textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelEditEquipment">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelEditEquipment" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -969,7 +967,6 @@ class EquipmentsPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -1058,8 +1055,8 @@ class EquipmentsPage {
                     <textarea name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelCreateOS">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelCreateOS" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -1074,7 +1071,6 @@ class EquipmentsPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -791,8 +791,8 @@ class InventoryPage {
                     <textarea name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelNewItem">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelNewItem" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -807,7 +807,6 @@ class InventoryPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -868,7 +867,7 @@ class InventoryPage {
                     ${item.fornecedor ? `<p><strong>Fornecedor:</strong> ${item.fornecedor}</p>` : ''}
                     ${item.observacoes ? `<p><strong>Observações:</strong> ${item.observacoes}</p>` : ''}
                 </div>
-                <div class="form-actions"><button id="closeItemDetails">Fechar</button></div>
+                <div class="form-actions"><button id="closeItemDetails" class="btn btn-secondary">Fechar</button></div>
             `;
             overlay.appendChild(modal);
             (document.getElementById('modals-container') || document.body).appendChild(overlay);
@@ -880,7 +879,6 @@ class InventoryPage {
                 style.textContent = `
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;margin-top:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -948,8 +946,8 @@ class InventoryPage {
                     <textarea name="observacoes" rows="2">${item.observacoes || ''}</textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelEditItem">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelEditItem" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -964,7 +962,6 @@ class InventoryPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:450px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }
@@ -1027,8 +1024,8 @@ class InventoryPage {
                     <input type="text" name="motivo" />
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelMovement">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelMovement" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;
@@ -1043,7 +1040,6 @@ class InventoryPage {
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:400px;max-height:80vh;overflow-y:auto;border-radius:4px;}
                     .custom-modal form{display:flex;flex-direction:column;gap:10px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;gap:10px;}
                 `;
                 document.head.appendChild(style);
             }

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -679,8 +679,8 @@ class WorkOrdersPage {
                 <textarea name="observacoes" rows="2"></textarea>
 
                 <div class="form-actions">
-                    <button type="submit">Salvar</button>
-                    <button type="button" id="cancelNewWorkOrder">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">Salvar</button>
+                    <button type="button" id="cancelNewWorkOrder" class="btn btn-secondary">Cancelar</button>
                 </div>
             </form>
         `;
@@ -712,11 +712,6 @@ class WorkOrdersPage {
                 .custom-modal form {
                     display: flex;
                     flex-direction: column;
-                    gap: 10px;
-                }
-                .custom-modal .form-actions {
-                    display: flex;
-                    justify-content: flex-end;
                     gap: 10px;
                 }
             `;
@@ -778,7 +773,7 @@ class WorkOrdersPage {
                     <p><strong>Descrição:</strong> ${os.descricao_problema || '-'}</p>
                     ${os.descricao_solucao ? `<p><strong>Solução:</strong> ${os.descricao_solucao}</p>` : ''}
                 </div>
-                <div class="form-actions"><button id="closeWorkOrderDetails">Fechar</button></div>
+                <div class="form-actions"><button id="closeWorkOrderDetails" class="btn btn-secondary">Fechar</button></div>
             `;
 
             overlay.appendChild(modal);
@@ -806,11 +801,6 @@ class WorkOrdersPage {
                         width: 450px;
                         max-height: 80vh;
                         overflow-y: auto;
-                    }
-                    .custom-modal .form-actions {
-                        display: flex;
-                        justify-content: flex-end;
-                        margin-top: 10px;
                     }
                 `;
                 document.head.appendChild(style);
@@ -898,8 +888,8 @@ class WorkOrdersPage {
                     <textarea name="observacoes" rows="2">${os.observacoes || ''}</textarea>
 
                     <div class="form-actions">
-                        <button type="submit">Salvar</button>
-                        <button type="button" id="cancelEditWorkOrder">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                        <button type="button" id="cancelEditWorkOrder" class="btn btn-secondary">Cancelar</button>
                     </div>
                 </form>
             `;

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -851,7 +851,7 @@ class TiresPage {
                         </table>
                     </div>
                 </div>
-                <div class="form-actions"><button id="closeReport">Fechar</button></div>
+                <div class="form-actions"><button id="closeReport" class="btn btn-secondary">Fechar</button></div>
             `;
 
             overlay.appendChild(modal);
@@ -865,7 +865,6 @@ class TiresPage {
                 style.textContent = `
                     .custom-modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:10000;}
                     .custom-modal{background:#fff;padding:20px;width:600px;max-height:80vh;overflow-y:auto;border-radius:4px;}
-                    .custom-modal .form-actions{display:flex;justify-content:flex-end;margin-top:10px;}
                     .report-section{margin-bottom:20px;}
                     .report-section h3{margin-bottom:10px;}
                 `;
@@ -921,8 +920,8 @@ class TiresPage {
             <input type="number" name="vida_util_estimada" step="0.01" />
 
             <div class="form-actions">
-                <button type="submit">Salvar</button>
-                <button type="button" id="cancelNewTire">Cancelar</button>
+                <button type="submit" class="btn btn-primary">Salvar</button>
+                <button type="button" id="cancelNewTire" class="btn btn-secondary">Cancelar</button>
             </div>
         </form>
     `;
@@ -960,11 +959,6 @@ class TiresPage {
             .custom-modal form {
                 display: flex;
                 flex-direction: column;
-                gap: 10px;
-            }
-            .custom-modal .form-actions {
-                display: flex;
-                justify-content: flex-end;
                 gap: 10px;
             }
             .custom-modal button {

--- a/src/static/js/tires.js
+++ b/src/static/js/tires.js
@@ -53,8 +53,8 @@ function openCreateTireModal() {
                 <input type="number" name="vida_util_estimada" step="0.01" />
 
                 <div class="form-actions">
-                    <button type="submit">Salvar</button>
-                    <button type="button" id="cancelNewTire">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">Salvar</button>
+                    <button type="button" id="cancelNewTire" class="btn btn-secondary">Cancelar</button>
                 </div>
             </form>
         </div>
@@ -127,11 +127,6 @@ modalStyle.textContent = `
 .custom-modal form {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-}
-.custom-modal .form-actions {
-    display: flex;
-    justify-content: flex-end;
     gap: 10px;
 }
 .custom-modal button {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -758,6 +758,13 @@ body {
     min-height: 100px;
 }
 
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 10px;
+}
+
 /* Status Badges */
 .badge {
     display: inline-flex;


### PR DESCRIPTION
## Sumário
- aplica classes `btn btn-primary`/`btn btn-secondary` em formulários de pneus, ordens de serviço, estoque e equipamentos
- centraliza estilo `.form-actions` em `styles.css`, removendo CSS duplicado

## Testes
- `python -m pytest`
- `node --check src/static/js/tires.js`
- `node --check src/static/js/pages/pneus.js`
- `node --check src/static/js/pages/ordens-servico.js`
- `node --check src/static/js/pages/estoque.js`
- `node --check src/static/js/pages/equipamentos.js`


------
https://chatgpt.com/codex/tasks/task_e_689100e03984832c84c76f5eff9d5717