### PR TITLE
Refactor form layout for responsive grid

### DIFF
--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -754,49 +754,63 @@ class EquipmentsPage {
             modal.innerHTML = `
                 <h2>Novo Equipamento</h2>
                 <form id="equipmentForm">
-                    <label>Código Interno*</label>
-                    <input type="text" name="codigo_interno" required />
-
-                    <label>Nome*</label>
-                    <input type="text" name="nome" required />
-
-                    <label>Tipo*</label>
-                    <select name="tipo" required>
-                        <option value="">Selecione...</option>
-                        ${types.map(t => `<option value="${t.nome}">${t.nome}</option>`).join('')}
-                    </select>
-
-                    <label>Modelo*</label>
-                    <input type="text" name="modelo" required />
-
-                    <label>Fabricante*</label>
-                    <input type="text" name="fabricante" required />
-
-                    <label>Número de Série*</label>
-                    <input type="text" name="numero_serie" required />
-
-                    <label>Status*</label>
-                    <select name="status" required>
-                        <option value="ativo">Ativo</option>
-                        <option value="manutencao">Em Manutenção</option>
-                        <option value="inativo">Inativo</option>
-                    </select>
-
-                    <label>Localização*</label>
-                    <input type="text" name="localizacao" required />
-
-                    <label>Horímetro Atual</label>
-                    <input type="number" name="horimetro_atual" step="0.01" />
-
-                    <label>Data de Aquisição*</label>
-                    <input type="date" name="data_aquisicao" required />
-
-                    <label>Valor de Aquisição</label>
-                    <input type="number" name="valor_aquisicao" step="0.01" />
-
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2"></textarea>
-
+                    <div class="form-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+                        <div class="form-group">
+                            <label class="form-label">Código Interno*</label>
+                            <input type="text" name="codigo_interno" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Nome*</label>
+                            <input type="text" name="nome" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Tipo*</label>
+                            <select name="tipo" class="form-select" required>
+                                <option value="">Selecione...</option>
+                                ${types.map(t => `<option value="${t.nome}">${t.nome}</option>`).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Modelo*</label>
+                            <input type="text" name="modelo" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Fabricante*</label>
+                            <input type="text" name="fabricante" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Número de Série*</label>
+                            <input type="text" name="numero_serie" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Status*</label>
+                            <select name="status" class="form-select" required>
+                                <option value="ativo">Ativo</option>
+                                <option value="manutencao">Em Manutenção</option>
+                                <option value="inativo">Inativo</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Localização*</label>
+                            <input type="text" name="localizacao" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Horímetro Atual</label>
+                            <input type="number" name="horimetro_atual" class="form-input" step="0.01" />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Data de Aquisição*</label>
+                            <input type="date" name="data_aquisicao" class="form-input" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Valor de Aquisição</label>
+                            <input type="number" name="valor_aquisicao" class="form-input" step="0.01" />
+                        </div>
+                        <div class="form-group" style="grid-column: 1 / -1;">
+                            <label class="form-label">Observações</label>
+                            <textarea name="observacoes" class="form-textarea" rows="2"></textarea>
+                        </div>
+                    </div>
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
                         <button type="button" id="cancelEquipment">Cancelar</button>
@@ -919,39 +933,50 @@ class EquipmentsPage {
             modal.innerHTML = `
                 <h2>Editar Equipamento</h2>
                 <form id="editEquipmentForm">
-                    <label>Nome*</label>
-                    <input type="text" name="nome" value="${eq.nome || ''}" required />
-
-                    <label>Tipo*</label>
-                    <select name="tipo" required>
-                        ${types.map(t => `<option value="${t.nome}" ${t.nome === (eq.tipo || eq.tipo_equipamento) ? 'selected' : ''}>${t.nome}</option>`).join('')}
-                    </select>
-
-                    <label>Modelo*</label>
-                    <input type="text" name="modelo" value="${eq.modelo || ''}" required />
-
-                    <label>Fabricante*</label>
-                    <input type="text" name="fabricante" value="${eq.fabricante || ''}" required />
-
-                    <label>Status*</label>
-                    <select name="status" required>
-                        <option value="ativo" ${eq.status === 'ativo' ? 'selected' : ''}>Ativo</option>
-                        <option value="manutencao" ${eq.status === 'manutencao' ? 'selected' : ''}>Em Manutenção</option>
-                        <option value="inativo" ${eq.status === 'inativo' ? 'selected' : ''}>Inativo</option>
-                    </select>
-
-                    <label>Localização*</label>
-                    <input type="text" name="localizacao" value="${eq.localizacao || ''}" required />
-
-                    <label>Horímetro Atual</label>
-                    <input type="number" name="horimetro_atual" step="0.01" value="${eq.horimetro_atual || 0}" />
-
-                    <label>Valor de Aquisição</label>
-                    <input type="number" name="valor_aquisicao" step="0.01" value="${eq.valor_aquisicao || ''}" />
-
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2">${eq.observacoes || ''}</textarea>
-
+                    <div class="form-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+                        <div class="form-group">
+                            <label class="form-label">Nome*</label>
+                            <input type="text" name="nome" class="form-input" value="${eq.nome || ''}" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Tipo*</label>
+                            <select name="tipo" class="form-select" required>
+                                ${types.map(t => `<option value="${t.nome}" ${t.nome === (eq.tipo || eq.tipo_equipamento) ? 'selected' : ''}>${t.nome}</option>`).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Modelo*</label>
+                            <input type="text" name="modelo" class="form-input" value="${eq.modelo || ''}" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Fabricante*</label>
+                            <input type="text" name="fabricante" class="form-input" value="${eq.fabricante || ''}" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Status*</label>
+                            <select name="status" class="form-select" required>
+                                <option value="ativo" ${eq.status === 'ativo' ? 'selected' : ''}>Ativo</option>
+                                <option value="manutencao" ${eq.status === 'manutencao' ? 'selected' : ''}>Em Manutenção</option>
+                                <option value="inativo" ${eq.status === 'inativo' ? 'selected' : ''}>Inativo</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Localização*</label>
+                            <input type="text" name="localizacao" class="form-input" value="${eq.localizacao || ''}" required />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Horímetro Atual</label>
+                            <input type="number" name="horimetro_atual" class="form-input" step="0.01" value="${eq.horimetro_atual || 0}" />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Valor de Aquisição</label>
+                            <input type="number" name="valor_aquisicao" class="form-input" step="0.01" value="${eq.valor_aquisicao || ''}" />
+                        </div>
+                        <div class="form-group" style="grid-column: 1 / -1;">
+                            <label class="form-label">Observações</label>
+                            <textarea name="observacoes" class="form-textarea" rows="2">${eq.observacoes || ''}</textarea>
+                        </div>
+                    </div>
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
                         <button type="button" id="cancelEditEquipment">Cancelar</button>

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -642,42 +642,51 @@ class WorkOrdersPage {
         modal.innerHTML = `
             <h2>Criar Ordem de Serviço</h2>
             <form id="newWorkOrderForm">
-                <label>Equipamento*</label>
-                <select name="equipamento_id" required>
-                    <option value="">Selecione...</option>
-                    ${equipments.map(e => `<option value="${e.id}">${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
-                </select>
-
-                <label>Tipo de Manutenção*</label>
-                <select name="tipo" required>
-                    <option value="">Selecione...</option>
-                    ${types.map(t => `<option value="${t.id}">${t.nome}</option>`).join('')}
-                </select>
-
-                <label>Prioridade*</label>
-                <select name="prioridade" required>
-                    <option value="">Selecione...</option>
-                    <option value="baixa">Baixa</option>
-                    <option value="media">Média</option>
-                    <option value="alta">Alta</option>
-                    <option value="critica">Crítica</option>
-                </select>
-
-                <label>Mecânico (opcional)</label>
-                <select name="mecanico_id">
-                    <option value="">Nenhum</option>
-                    ${mechanics.map(m => `<option value="${m.id}">${m.nome_completo || m.nome}</option>`).join('')}
-                </select>
-
-                <label>Data Prevista</label>
-                <input type="datetime-local" name="data_prevista" />
-
-                <label>Descrição do Problema*</label>
-                <textarea name="descricao_problema" rows="3" required></textarea>
-
-                <label>Observações</label>
-                <textarea name="observacoes" rows="2"></textarea>
-
+                <div class="form-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+                    <div class="form-group">
+                        <label class="form-label">Equipamento*</label>
+                        <select name="equipamento_id" class="form-select" required>
+                            <option value="">Selecione...</option>
+                            ${equipments.map(e => `<option value="${e.id}">${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Tipo de Manutenção*</label>
+                        <select name="tipo" class="form-select" required>
+                            <option value="">Selecione...</option>
+                            ${types.map(t => `<option value="${t.id}">${t.nome}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Prioridade*</label>
+                        <select name="prioridade" class="form-select" required>
+                            <option value="">Selecione...</option>
+                            <option value="baixa">Baixa</option>
+                            <option value="media">Média</option>
+                            <option value="alta">Alta</option>
+                            <option value="critica">Crítica</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Mecânico (opcional)</label>
+                        <select name="mecanico_id" class="form-select">
+                            <option value="">Nenhum</option>
+                            ${mechanics.map(m => `<option value="${m.id}">${m.nome_completo || m.nome}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Data Prevista</label>
+                        <input type="datetime-local" name="data_prevista" class="form-input" />
+                    </div>
+                    <div class="form-group" style="grid-column: 1 / -1;">
+                        <label class="form-label">Descrição do Problema*</label>
+                        <textarea name="descricao_problema" class="form-textarea" rows="3" required></textarea>
+                    </div>
+                    <div class="form-group" style="grid-column: 1 / -1;">
+                        <label class="form-label">Observações</label>
+                        <textarea name="observacoes" class="form-textarea" rows="2"></textarea>
+                    </div>
+                </div>
                 <div class="form-actions">
                     <button type="submit">Salvar</button>
                     <button type="button" id="cancelNewWorkOrder">Cancelar</button>
@@ -861,42 +870,51 @@ class WorkOrdersPage {
             modal.innerHTML = `
                 <h2>Editar Ordem de Serviço</h2>
                 <form id="editWorkOrderForm">
-                    <label>Equipamento*</label>
-                    <select name="equipamento_id" required>
-                        <option value="">Selecione...</option>
-                        ${equipments.map(e => `<option value="${e.id}" ${e.id === os.equipamento_id ? 'selected' : ''}>${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
-                    </select>
-
-                    <label>Tipo de Manutenção*</label>
-                    <select name="tipo" required>
-                        <option value="">Selecione...</option>
-                        ${types.map(t => `<option value="${t.id}" ${t.id === (os.tipo_manutencao_id || os.tipo) ? 'selected' : ''}>${t.nome}</option>`).join('')}
-                    </select>
-
-                    <label>Prioridade*</label>
-                    <select name="prioridade" required>
-                        <option value="">Selecione...</option>
-                        <option value="baixa" ${os.prioridade === 'baixa' ? 'selected' : ''}>Baixa</option>
-                        <option value="media" ${os.prioridade === 'media' ? 'selected' : ''}>Média</option>
-                        <option value="alta" ${os.prioridade === 'alta' ? 'selected' : ''}>Alta</option>
-                        <option value="critica" ${os.prioridade === 'critica' ? 'selected' : ''}>Crítica</option>
-                    </select>
-
-                    <label>Mecânico (opcional)</label>
-                    <select name="mecanico_id">
-                        <option value="">Nenhum</option>
-                        ${mechanics.map(m => `<option value="${m.id}" ${m.id === os.mecanico_id ? 'selected' : ''}>${m.nome_completo || m.nome}</option>`).join('')}
-                    </select>
-
-                    <label>Data Prevista</label>
-                    <input type="datetime-local" name="data_prevista" value="${os.data_prevista ? new Date(os.data_prevista).toISOString().slice(0,16) : ''}" />
-
-                    <label>Descrição do Problema*</label>
-                    <textarea name="descricao_problema" rows="3" required>${os.descricao_problema || ''}</textarea>
-
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2">${os.observacoes || ''}</textarea>
-
+                    <div class="form-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+                        <div class="form-group">
+                            <label class="form-label">Equipamento*</label>
+                            <select name="equipamento_id" class="form-select" required>
+                                <option value="">Selecione...</option>
+                                ${equipments.map(e => `<option value="${e.id}" ${e.id === os.equipamento_id ? 'selected' : ''}>${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Tipo de Manutenção*</label>
+                            <select name="tipo" class="form-select" required>
+                                <option value="">Selecione...</option>
+                                ${types.map(t => `<option value="${t.id}" ${t.id === (os.tipo_manutencao_id || os.tipo) ? 'selected' : ''}>${t.nome}</option>`).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Prioridade*</label>
+                            <select name="prioridade" class="form-select" required>
+                                <option value="">Selecione...</option>
+                                <option value="baixa" ${os.prioridade === 'baixa' ? 'selected' : ''}>Baixa</option>
+                                <option value="media" ${os.prioridade === 'media' ? 'selected' : ''}>Média</option>
+                                <option value="alta" ${os.prioridade === 'alta' ? 'selected' : ''}>Alta</option>
+                                <option value="critica" ${os.prioridade === 'critica' ? 'selected' : ''}>Crítica</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Mecânico (opcional)</label>
+                            <select name="mecanico_id" class="form-select">
+                                <option value="">Nenhum</option>
+                                ${mechanics.map(m => `<option value="${m.id}" ${m.id === os.mecanico_id ? 'selected' : ''}>${m.nome_completo || m.nome}</option>`).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Data Prevista</label>
+                            <input type="datetime-local" name="data_prevista" class="form-input" value="${os.data_prevista ? new Date(os.data_prevista).toISOString().slice(0,16) : ''}" />
+                        </div>
+                        <div class="form-group" style="grid-column: 1 / -1;">
+                            <label class="form-label">Descrição do Problema*</label>
+                            <textarea name="descricao_problema" class="form-textarea" rows="3" required>${os.descricao_problema || ''}</textarea>
+                        </div>
+                        <div class="form-group" style="grid-column: 1 / -1;">
+                            <label class="form-label">Observações</label>
+                            <textarea name="observacoes" class="form-textarea" rows="2">${os.observacoes || ''}</textarea>
+                        </div>
+                    </div>
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
                         <button type="button" id="cancelEditWorkOrder">Cancelar</button>


### PR DESCRIPTION
## Summary
- wrap equipment and work order forms in responsive grid containers
- add form-group wrappers and input classes for consistent styling

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689100d8cf70832c81106b336aa28801