### PR TITLE
Ensure form fields have ids and label associations

### DIFF
--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -754,48 +754,48 @@ class EquipmentsPage {
             modal.innerHTML = `
                 <h2>Novo Equipamento</h2>
                 <form id="equipmentForm">
-                    <label>Código Interno*</label>
-                    <input type="text" name="codigo_interno" required />
+                    <label for="equipment-codigo_interno">Código Interno*</label>
+                    <input type="text" id="equipment-codigo_interno" name="codigo_interno" required />
 
-                    <label>Nome*</label>
-                    <input type="text" name="nome" required />
+                    <label for="equipment-nome">Nome*</label>
+                    <input type="text" id="equipment-nome" name="nome" required />
 
-                    <label>Tipo*</label>
-                    <select name="tipo" required>
+                    <label for="equipment-tipo">Tipo*</label>
+                    <select id="equipment-tipo" name="tipo" required>
                         <option value="">Selecione...</option>
                         ${types.map(t => `<option value="${t.nome}">${t.nome}</option>`).join('')}
                     </select>
 
-                    <label>Modelo*</label>
-                    <input type="text" name="modelo" required />
+                    <label for="equipment-modelo">Modelo*</label>
+                    <input type="text" id="equipment-modelo" name="modelo" required />
 
-                    <label>Fabricante*</label>
-                    <input type="text" name="fabricante" required />
+                    <label for="equipment-fabricante">Fabricante*</label>
+                    <input type="text" id="equipment-fabricante" name="fabricante" required />
 
-                    <label>Número de Série*</label>
-                    <input type="text" name="numero_serie" required />
+                    <label for="equipment-numero_serie">Número de Série*</label>
+                    <input type="text" id="equipment-numero_serie" name="numero_serie" required />
 
-                    <label>Status*</label>
-                    <select name="status" required>
+                    <label for="equipment-status">Status*</label>
+                    <select id="equipment-status" name="status" required>
                         <option value="ativo">Ativo</option>
                         <option value="manutencao">Em Manutenção</option>
                         <option value="inativo">Inativo</option>
                     </select>
 
-                    <label>Localização*</label>
-                    <input type="text" name="localizacao" required />
+                    <label for="equipment-localizacao">Localização*</label>
+                    <input type="text" id="equipment-localizacao" name="localizacao" required />
 
-                    <label>Horímetro Atual</label>
-                    <input type="number" name="horimetro_atual" step="0.01" />
+                    <label for="equipment-horimetro_atual">Horímetro Atual</label>
+                    <input type="number" id="equipment-horimetro_atual" name="horimetro_atual" step="0.01" />
 
-                    <label>Data de Aquisição*</label>
-                    <input type="date" name="data_aquisicao" required />
+                    <label for="equipment-data_aquisicao">Data de Aquisição*</label>
+                    <input type="date" id="equipment-data_aquisicao" name="data_aquisicao" required />
 
-                    <label>Valor de Aquisição</label>
-                    <input type="number" name="valor_aquisicao" step="0.01" />
+                    <label for="equipment-valor_aquisicao">Valor de Aquisição</label>
+                    <input type="number" id="equipment-valor_aquisicao" name="valor_aquisicao" step="0.01" />
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2"></textarea>
+                    <label for="equipment-observacoes">Observações</label>
+                    <textarea id="equipment-observacoes" name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
@@ -919,38 +919,38 @@ class EquipmentsPage {
             modal.innerHTML = `
                 <h2>Editar Equipamento</h2>
                 <form id="editEquipmentForm">
-                    <label>Nome*</label>
-                    <input type="text" name="nome" value="${eq.nome || ''}" required />
+                    <label for="edit-equipment-nome">Nome*</label>
+                    <input type="text" id="edit-equipment-nome" name="nome" value="${eq.nome || ''}" required />
 
-                    <label>Tipo*</label>
-                    <select name="tipo" required>
+                    <label for="edit-equipment-tipo">Tipo*</label>
+                    <select id="edit-equipment-tipo" name="tipo" required>
                         ${types.map(t => `<option value="${t.nome}" ${t.nome === (eq.tipo || eq.tipo_equipamento) ? 'selected' : ''}>${t.nome}</option>`).join('')}
                     </select>
 
-                    <label>Modelo*</label>
-                    <input type="text" name="modelo" value="${eq.modelo || ''}" required />
+                    <label for="edit-equipment-modelo">Modelo*</label>
+                    <input type="text" id="edit-equipment-modelo" name="modelo" value="${eq.modelo || ''}" required />
 
-                    <label>Fabricante*</label>
-                    <input type="text" name="fabricante" value="${eq.fabricante || ''}" required />
+                    <label for="edit-equipment-fabricante">Fabricante*</label>
+                    <input type="text" id="edit-equipment-fabricante" name="fabricante" value="${eq.fabricante || ''}" required />
 
-                    <label>Status*</label>
-                    <select name="status" required>
+                    <label for="edit-equipment-status">Status*</label>
+                    <select id="edit-equipment-status" name="status" required>
                         <option value="ativo" ${eq.status === 'ativo' ? 'selected' : ''}>Ativo</option>
                         <option value="manutencao" ${eq.status === 'manutencao' ? 'selected' : ''}>Em Manutenção</option>
                         <option value="inativo" ${eq.status === 'inativo' ? 'selected' : ''}>Inativo</option>
                     </select>
 
-                    <label>Localização*</label>
-                    <input type="text" name="localizacao" value="${eq.localizacao || ''}" required />
+                    <label for="edit-equipment-localizacao">Localização*</label>
+                    <input type="text" id="edit-equipment-localizacao" name="localizacao" value="${eq.localizacao || ''}" required />
 
-                    <label>Horímetro Atual</label>
-                    <input type="number" name="horimetro_atual" step="0.01" value="${eq.horimetro_atual || 0}" />
+                    <label for="edit-equipment-horimetro_atual">Horímetro Atual</label>
+                    <input type="number" id="edit-equipment-horimetro_atual" name="horimetro_atual" step="0.01" value="${eq.horimetro_atual || 0}" />
 
-                    <label>Valor de Aquisição</label>
-                    <input type="number" name="valor_aquisicao" step="0.01" value="${eq.valor_aquisicao || ''}" />
+                    <label for="edit-equipment-valor_aquisicao">Valor de Aquisição</label>
+                    <input type="number" id="edit-equipment-valor_aquisicao" name="valor_aquisicao" step="0.01" value="${eq.valor_aquisicao || ''}" />
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2">${eq.observacoes || ''}</textarea>
+                    <label for="edit-equipment-observacoes">Observações</label>
+                    <textarea id="edit-equipment-observacoes" name="observacoes" rows="2">${eq.observacoes || ''}</textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
@@ -1024,38 +1024,38 @@ class EquipmentsPage {
             modal.innerHTML = `
                 <h2>Nova Ordem de Serviço</h2>
                 <form id="osFromEquipment">
-                    <label>Equipamento</label>
-                    <input type="text" value="${equipment.nome}" disabled />
-                    <input type="hidden" name="equipamento_id" value="${equipmentId}" />
+                    <label for="os-equipamento-nome">Equipamento</label>
+                    <input type="text" id="os-equipamento-nome" value="${equipment.nome}" disabled />
+                    <input type="hidden" id="os-equipamento-id" name="equipamento_id" value="${equipmentId}" />
 
-                    <label>Tipo de Manutenção*</label>
-                    <select name="tipo" required>
+                    <label for="os-tipo">Tipo de Manutenção*</label>
+                    <select id="os-tipo" name="tipo" required>
                         <option value="">Selecione...</option>
                         ${types.map(t => `<option value="${t.id}">${t.nome}</option>`).join('')}
                     </select>
 
-                    <label>Prioridade*</label>
-                    <select name="prioridade" required>
+                    <label for="os-prioridade">Prioridade*</label>
+                    <select id="os-prioridade" name="prioridade" required>
                         <option value="baixa">Baixa</option>
                         <option value="media">Média</option>
                         <option value="alta">Alta</option>
                         <option value="critica">Crítica</option>
                     </select>
 
-                    <label>Mecânico (opcional)</label>
-                    <select name="mecanico_id">
+                    <label for="os-mecanico_id">Mecânico (opcional)</label>
+                    <select id="os-mecanico_id" name="mecanico_id">
                         <option value="">Nenhum</option>
                         ${mechanics.map(m => `<option value="${m.id}">${m.nome_completo || m.nome}</option>`).join('')}
                     </select>
 
-                    <label>Data Prevista</label>
-                    <input type="datetime-local" name="data_prevista" />
+                    <label for="os-data_prevista">Data Prevista</label>
+                    <input type="datetime-local" id="os-data_prevista" name="data_prevista" />
 
-                    <label>Descrição do Problema*</label>
-                    <textarea name="descricao_problema" rows="3" required></textarea>
+                    <label for="os-descricao_problema">Descrição do Problema*</label>
+                    <textarea id="os-descricao_problema" name="descricao_problema" rows="3" required></textarea>
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2"></textarea>
+                    <label for="os-observacoes">Observações</label>
+                    <textarea id="os-observacoes" name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -751,44 +751,44 @@ class InventoryPage {
             modal.innerHTML = `
                 <h2>Nova Peça</h2>
                 <form id="newItemForm">
-                    <label>Código*</label>
-                    <input type="text" name="codigo" required />
+                    <label for="new-item-codigo">Código*</label>
+                    <input type="text" id="new-item-codigo" name="codigo" required />
 
-                    <label>Nome*</label>
-                    <input type="text" name="nome" required />
+                    <label for="new-item-nome">Nome*</label>
+                    <input type="text" id="new-item-nome" name="nome" required />
 
-                    <label>Grupo*</label>
-                    <select name="grupo_item_id" required>
+                    <label for="new-item-grupo_item_id">Grupo*</label>
+                    <select id="new-item-grupo_item_id" name="grupo_item_id" required>
                         <option value="">Selecione...</option>
                         ${grupos.map(g => `<option value="${g.id}">${g.nome}</option>`).join('')}
                     </select>
 
-                    <label>Descrição</label>
-                    <input type="text" name="descricao" />
+                    <label for="new-item-descricao">Descrição</label>
+                    <input type="text" id="new-item-descricao" name="descricao" />
 
-                    <label>Unidade*</label>
-                    <input type="text" name="unidade" required />
+                    <label for="new-item-unidade">Unidade*</label>
+                    <input type="text" id="new-item-unidade" name="unidade" required />
 
-                    <label>Quantidade Inicial</label>
-                    <input type="number" name="quantidade" step="0.01" />
+                    <label for="new-item-quantidade">Quantidade Inicial</label>
+                    <input type="number" id="new-item-quantidade" name="quantidade" step="0.01" />
 
-                    <label>Estoque Mínimo</label>
-                    <input type="number" name="min_estoque" />
+                    <label for="new-item-min_estoque">Estoque Mínimo</label>
+                    <input type="number" id="new-item-min_estoque" name="min_estoque" />
 
-                    <label>Preço Unitário</label>
-                    <input type="number" name="preco_unitario" step="0.01" />
+                    <label for="new-item-preco_unitario">Preço Unitário</label>
+                    <input type="number" id="new-item-preco_unitario" name="preco_unitario" step="0.01" />
 
-                    <label>Local</label>
-                    <select name="estoque_local_id">
+                    <label for="new-item-estoque_local_id">Local</label>
+                    <select id="new-item-estoque_local_id" name="estoque_local_id">
                         <option value="">Selecione...</option>
                         ${locais.map(l => `<option value="${l.id}">${l.nome}</option>`).join('')}
                     </select>
 
-                    <label>Fornecedor</label>
-                    <input type="text" name="fornecedor" />
+                    <label for="new-item-fornecedor">Fornecedor</label>
+                    <input type="text" id="new-item-fornecedor" name="fornecedor" />
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2"></textarea>
+                    <label for="new-item-observacoes">Observações</label>
+                    <textarea id="new-item-observacoes" name="observacoes" rows="2"></textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
@@ -909,43 +909,43 @@ class InventoryPage {
             modal.innerHTML = `
                 <h2>Editar Item</h2>
                 <form id="editItemForm">
-                    <label>Código</label>
-                    <input type="text" value="${item.codigo}" disabled />
+                    <label for="edit-item-codigo">Código</label>
+                    <input type="text" id="edit-item-codigo" value="${item.codigo}" disabled />
 
-                    <label>Nome*</label>
-                    <input type="text" name="nome" value="${item.nome}" required />
+                    <label for="edit-item-nome">Nome*</label>
+                    <input type="text" id="edit-item-nome" name="nome" value="${item.nome}" required />
 
-                    <label>Grupo*</label>
-                    <select name="grupo_item_id" required>
+                    <label for="edit-item-grupo_item_id">Grupo*</label>
+                    <select id="edit-item-grupo_item_id" name="grupo_item_id" required>
                         ${grupos.map(g => `<option value="${g.id}" ${g.id === item.grupo_item_id ? 'selected' : ''}>${g.nome}</option>`).join('')}
                     </select>
 
-                    <label>Descrição</label>
-                    <input type="text" name="descricao" value="${item.descricao || ''}" />
+                    <label for="edit-item-descricao">Descrição</label>
+                    <input type="text" id="edit-item-descricao" name="descricao" value="${item.descricao || ''}" />
 
-                    <label>Unidade*</label>
-                    <input type="text" name="unidade" value="${item.unidade}" required />
+                    <label for="edit-item-unidade">Unidade*</label>
+                    <input type="text" id="edit-item-unidade" name="unidade" value="${item.unidade}" required />
 
-                    <label>Quantidade</label>
-                    <input type="number" name="quantidade" step="0.01" value="${item.quantidade_atual || item.quantidade || 0}" />
+                    <label for="edit-item-quantidade">Quantidade</label>
+                    <input type="number" id="edit-item-quantidade" name="quantidade" step="0.01" value="${item.quantidade_atual || item.quantidade || 0}" />
 
-                    <label>Estoque Mínimo</label>
-                    <input type="number" name="min_estoque" value="${item.estoque_minimo || item.min_estoque || 0}" />
+                    <label for="edit-item-min_estoque">Estoque Mínimo</label>
+                    <input type="number" id="edit-item-min_estoque" name="min_estoque" value="${item.estoque_minimo || item.min_estoque || 0}" />
 
-                    <label>Preço Unitário</label>
-                    <input type="number" name="preco_unitario" step="0.01" value="${item.preco_unitario || 0}" />
+                    <label for="edit-item-preco_unitario">Preço Unitário</label>
+                    <input type="number" id="edit-item-preco_unitario" name="preco_unitario" step="0.01" value="${item.preco_unitario || 0}" />
 
-                    <label>Local</label>
-                    <select name="estoque_local_id">
+                    <label for="edit-item-estoque_local_id">Local</label>
+                    <select id="edit-item-estoque_local_id" name="estoque_local_id">
                         <option value="">Selecione...</option>
                         ${locais.map(l => `<option value="${l.id}" ${l.id === item.estoque_local_id ? 'selected' : ''}>${l.nome}</option>`).join('')}
                     </select>
 
-                    <label>Fornecedor</label>
-                    <input type="text" name="fornecedor" value="${item.fornecedor || ''}" />
+                    <label for="edit-item-fornecedor">Fornecedor</label>
+                    <input type="text" id="edit-item-fornecedor" name="fornecedor" value="${item.fornecedor || ''}" />
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2">${item.observacoes || ''}</textarea>
+                    <label for="edit-item-observacoes">Observações</label>
+                    <textarea id="edit-item-observacoes" name="observacoes" rows="2">${item.observacoes || ''}</textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>
@@ -1014,17 +1014,17 @@ class InventoryPage {
                 <h2>Movimentar Estoque</h2>
                 <form id="movementForm">
                     <p><strong>${item.nome}</strong> (${item.codigo})</p>
-                    <label>Tipo*</label>
-                    <select name="tipo" required>
+                    <label for="movement-tipo">Tipo*</label>
+                    <select id="movement-tipo" name="tipo" required>
                         <option value="entrada">Entrada</option>
                         <option value="saida">Saída</option>
                     </select>
 
-                    <label>Quantidade*</label>
-                    <input type="number" name="quantidade" step="0.01" required />
+                    <label for="movement-quantidade">Quantidade*</label>
+                    <input type="number" id="movement-quantidade" name="quantidade" step="0.01" required />
 
-                    <label>Motivo</label>
-                    <input type="text" name="motivo" />
+                    <label for="movement-motivo">Motivo</label>
+                    <input type="text" id="movement-motivo" name="motivo" />
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -642,20 +642,20 @@ class WorkOrdersPage {
         modal.innerHTML = `
             <h2>Criar Ordem de Serviço</h2>
             <form id="newWorkOrderForm">
-                <label>Equipamento*</label>
-                <select name="equipamento_id" required>
+                <label for="nwo-equipamento_id">Equipamento*</label>
+                <select id="nwo-equipamento_id" name="equipamento_id" required>
                     <option value="">Selecione...</option>
                     ${equipments.map(e => `<option value="${e.id}">${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
                 </select>
 
-                <label>Tipo de Manutenção*</label>
-                <select name="tipo" required>
+                <label for="nwo-tipo">Tipo de Manutenção*</label>
+                <select id="nwo-tipo" name="tipo" required>
                     <option value="">Selecione...</option>
                     ${types.map(t => `<option value="${t.id}">${t.nome}</option>`).join('')}
                 </select>
 
-                <label>Prioridade*</label>
-                <select name="prioridade" required>
+                <label for="nwo-prioridade">Prioridade*</label>
+                <select id="nwo-prioridade" name="prioridade" required>
                     <option value="">Selecione...</option>
                     <option value="baixa">Baixa</option>
                     <option value="media">Média</option>
@@ -663,20 +663,20 @@ class WorkOrdersPage {
                     <option value="critica">Crítica</option>
                 </select>
 
-                <label>Mecânico (opcional)</label>
-                <select name="mecanico_id">
+                <label for="nwo-mecanico_id">Mecânico (opcional)</label>
+                <select id="nwo-mecanico_id" name="mecanico_id">
                     <option value="">Nenhum</option>
                     ${mechanics.map(m => `<option value="${m.id}">${m.nome_completo || m.nome}</option>`).join('')}
                 </select>
 
-                <label>Data Prevista</label>
-                <input type="datetime-local" name="data_prevista" />
+                <label for="nwo-data_prevista">Data Prevista</label>
+                <input type="datetime-local" id="nwo-data_prevista" name="data_prevista" />
 
-                <label>Descrição do Problema*</label>
-                <textarea name="descricao_problema" rows="3" required></textarea>
+                <label for="nwo-descricao_problema">Descrição do Problema*</label>
+                <textarea id="nwo-descricao_problema" name="descricao_problema" rows="3" required></textarea>
 
-                <label>Observações</label>
-                <textarea name="observacoes" rows="2"></textarea>
+                <label for="nwo-observacoes">Observações</label>
+                <textarea id="nwo-observacoes" name="observacoes" rows="2"></textarea>
 
                 <div class="form-actions">
                     <button type="submit">Salvar</button>
@@ -861,20 +861,20 @@ class WorkOrdersPage {
             modal.innerHTML = `
                 <h2>Editar Ordem de Serviço</h2>
                 <form id="editWorkOrderForm">
-                    <label>Equipamento*</label>
-                    <select name="equipamento_id" required>
+                    <label for="ewo-equipamento_id">Equipamento*</label>
+                    <select id="ewo-equipamento_id" name="equipamento_id" required>
                         <option value="">Selecione...</option>
                         ${equipments.map(e => `<option value="${e.id}" ${e.id === os.equipamento_id ? 'selected' : ''}>${e.nome || e.modelo || e.codigo_interno}</option>`).join('')}
                     </select>
 
-                    <label>Tipo de Manutenção*</label>
-                    <select name="tipo" required>
+                    <label for="ewo-tipo">Tipo de Manutenção*</label>
+                    <select id="ewo-tipo" name="tipo" required>
                         <option value="">Selecione...</option>
                         ${types.map(t => `<option value="${t.id}" ${t.id === (os.tipo_manutencao_id || os.tipo) ? 'selected' : ''}>${t.nome}</option>`).join('')}
                     </select>
 
-                    <label>Prioridade*</label>
-                    <select name="prioridade" required>
+                    <label for="ewo-prioridade">Prioridade*</label>
+                    <select id="ewo-prioridade" name="prioridade" required>
                         <option value="">Selecione...</option>
                         <option value="baixa" ${os.prioridade === 'baixa' ? 'selected' : ''}>Baixa</option>
                         <option value="media" ${os.prioridade === 'media' ? 'selected' : ''}>Média</option>
@@ -882,20 +882,20 @@ class WorkOrdersPage {
                         <option value="critica" ${os.prioridade === 'critica' ? 'selected' : ''}>Crítica</option>
                     </select>
 
-                    <label>Mecânico (opcional)</label>
-                    <select name="mecanico_id">
+                    <label for="ewo-mecanico_id">Mecânico (opcional)</label>
+                    <select id="ewo-mecanico_id" name="mecanico_id">
                         <option value="">Nenhum</option>
                         ${mechanics.map(m => `<option value="${m.id}" ${m.id === os.mecanico_id ? 'selected' : ''}>${m.nome_completo || m.nome}</option>`).join('')}
                     </select>
 
-                    <label>Data Prevista</label>
-                    <input type="datetime-local" name="data_prevista" value="${os.data_prevista ? new Date(os.data_prevista).toISOString().slice(0,16) : ''}" />
+                    <label for="ewo-data_prevista">Data Prevista</label>
+                    <input type="datetime-local" id="ewo-data_prevista" name="data_prevista" value="${os.data_prevista ? new Date(os.data_prevista).toISOString().slice(0,16) : ''}" />
 
-                    <label>Descrição do Problema*</label>
-                    <textarea name="descricao_problema" rows="3" required>${os.descricao_problema || ''}</textarea>
+                    <label for="ewo-descricao_problema">Descrição do Problema*</label>
+                    <textarea id="ewo-descricao_problema" name="descricao_problema" rows="3" required>${os.descricao_problema || ''}</textarea>
 
-                    <label>Observações</label>
-                    <textarea name="observacoes" rows="2">${os.observacoes || ''}</textarea>
+                    <label for="ewo-observacoes">Observações</label>
+                    <textarea id="ewo-observacoes" name="observacoes" rows="2">${os.observacoes || ''}</textarea>
 
                     <div class="form-actions">
                         <button type="submit">Salvar</button>

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -887,38 +887,38 @@ class TiresPage {
     modal.innerHTML = `
         <h2>Cadastrar Pneu</h2>
         <form id="newTireForm">
-            <label>Número de Série*</label>
-            <input type="text" name="numero_serie" required />
+            <label for="tire-numero_serie">Número de Série*</label>
+            <input type="text" id="tire-numero_serie" name="numero_serie" required />
 
-            <label>Número de Fogo</label>
-            <input type="text" name="numero_fogo" />
+            <label for="tire-numero_fogo">Número de Fogo</label>
+            <input type="text" id="tire-numero_fogo" name="numero_fogo" />
 
-            <label>Marca*</label>
-            <input type="text" name="marca" required />
+            <label for="tire-marca">Marca*</label>
+            <input type="text" id="tire-marca" name="marca" required />
 
-            <label>Modelo*</label>
-            <input type="text" name="modelo" required />
+            <label for="tire-modelo">Modelo*</label>
+            <input type="text" id="tire-modelo" name="modelo" required />
 
-            <label>Medida* (ex.: 385/65R22.5)</label>
-            <input type="text" name="medida" required />
+            <label for="tire-medida">Medida* (ex.: 385/65R22.5)</label>
+            <input type="text" id="tire-medida" name="medida" required />
 
-            <label>Tipo*</label>
-            <select name="tipo" required>
+            <label for="tire-tipo">Tipo*</label>
+            <select id="tire-tipo" name="tipo" required>
                 <option value="novo">Novo</option>
                 <option value="recapado">Recapado</option>
             </select>
 
-            <label>Data de Compra*</label>
-            <input type="date" name="data_compra" required />
+            <label for="tire-data_compra">Data de Compra*</label>
+            <input type="date" id="tire-data_compra" name="data_compra" required />
 
-            <label>Valor de Compra</label>
-            <input type="number" name="valor_compra" step="0.01" />
+            <label for="tire-valor_compra">Valor de Compra</label>
+            <input type="number" id="tire-valor_compra" name="valor_compra" step="0.01" />
 
-            <label>Pressão Recomendada (PSI)</label>
-            <input type="number" name="pressao_recomendada" step="0.01" />
+            <label for="tire-pressao_recomendada">Pressão Recomendada (PSI)</label>
+            <input type="number" id="tire-pressao_recomendada" name="pressao_recomendada" step="0.01" />
 
-            <label>Vida Útil Estimada (km)</label>
-            <input type="number" name="vida_util_estimada" step="0.01" />
+            <label for="tire-vida_util_estimada">Vida Útil Estimada (km)</label>
+            <input type="number" id="tire-vida_util_estimada" name="vida_util_estimada" step="0.01" />
 
             <div class="form-actions">
                 <button type="submit">Salvar</button>


### PR DESCRIPTION
## Summary
- Add unique `id` values to inputs, selects and textareas in equipment, inventory, tire and work order pages
- Link labels to their fields via `for` attributes to improve accessibility
- Keep required fields explicitly marked for browser validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689100d36aa8832c9ce80b8aef1df21f