### PR TITLE
Fix relationship conflict for equipment types

### DIFF
--- a/src/models/equipamento.py
+++ b/src/models/equipamento.py
@@ -23,7 +23,12 @@ class Equipamento(db.Model):
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     # Relacionamentos
-    tipo_equipamento_obj = db.relationship('TipoEquipamento', backref='equipamentos', lazy=True)
+    # Use back_populates para vincular explicitamente com TipoEquipamento e
+    # evitar a criação automática de um backref que causa conflito quando o
+    # relacionamento oposto também define um atributo.
+    tipo_equipamento_obj = db.relationship(
+        'TipoEquipamento', back_populates='equipamentos', lazy=True
+    )
     ordens_servico = db.relationship('OrdemServico', backref='equipamento', lazy=True)
 
     def to_dict(self):

--- a/src/models/tipo_equipamento.py
+++ b/src/models/tipo_equipamento.py
@@ -12,7 +12,11 @@ class TipoEquipamento(db.Model):
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     
     # Relacionamentos
-    equipamentos = db.relationship('Equipamento', backref='tipo_equipamento_obj', lazy=True)
+    # Relacionamento bidirecional com Equipamento utilizando back_populates
+    # para evitar a criação automática de atributos duplicados.
+    equipamentos = db.relationship(
+        'Equipamento', back_populates='tipo_equipamento_obj', lazy=True
+    )
     
     def to_dict(self):
         return {


### PR DESCRIPTION
## Summary
- resolve SQLAlchemy backref conflict between equipment and equipment type models

## Testing
- `pytest`
- `python src/main.py` (fails: DATABASE_URL não configurada)


------
https://chatgpt.com/codex/tasks/task_e_689141439160832cb956324eb671d7c9