### PR TITLE
Ensure schema updated with origem column at startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,10 +141,13 @@ if __name__ == '__main__':
     # Criar tabelas se não existirem e popular dados de exemplo
     with app.app_context():
         db.create_all()
+
+        # Garantir que o esquema esteja atualizado antes de qualquer consulta
+        from init_db import ensure_schema, criar_dados_exemplo
+        ensure_schema()
         print("✅ Tabelas do banco de dados criadas/verificadas")
-        
+
         # Importar e chamar a função de criação de dados de exemplo
-        from init_db import criar_dados_exemplo
         criar_dados_exemplo()
     
     app.run(host='0.0.0.0', port=port, debug=False)


### PR DESCRIPTION
## Summary
- confirm ensure_schema adds missing `origem` column to `ordens_servico`
- call `ensure_schema()` after `db.create_all()` so schema upgrades run on startup

## Testing
- `python -m pytest`
- `DATABASE_URL=sqlite:////workspace/cmms_sistema/instance/test_schema.db python init_db.py`
- `sqlite3 instance/test_schema.db '.schema ordens_servico'`


------
https://chatgpt.com/codex/tasks/task_e_68915ba0fa3c832ca1cb11938152653a