### PR TITLE
Ensure database schema is verified before seeding

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -58,6 +58,15 @@ def run_migrations():
     alembic_cfg = Config(os.path.join(current_dir, 'alembic.ini'))
     command.upgrade(alembic_cfg, 'head')
 
+def ensure_schema():
+    """Garantir que o esquema do banco esteja atualizado antes de manipular dados."""
+    try:
+        run_migrations()
+        print("✅ Esquema do banco verificado")
+    except Exception as e:
+        print(f"❌ Falha ao verificar esquema do banco: {e}")
+        raise
+
 def criar_dados_exemplo():
     """Função para criar dados de exemplo no banco"""
     print("🔄 Iniciando criação de dados de exemplo...")

--- a/src/main.py
+++ b/src/main.py
@@ -138,16 +138,16 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
     print(f"🌐 Servidor CMMS rodando na porta {port}")
 
-    # Aplicar migrações e popular dados de exemplo
+    # Verificar esquema e popular dados de exemplo
     with app.app_context():
-        from alembic import command
-        from alembic.config import Config
+        from init_db import ensure_schema, criar_dados_exemplo
 
-        alembic_cfg = Config(os.path.join(os.path.dirname(__file__), '..', 'alembic.ini'))
-        command.upgrade(alembic_cfg, "head")
-        print("✅ Migrações aplicadas")
+        try:
+            ensure_schema()
+        except Exception as e:
+            print(f"❌ Falha ao verificar esquema do banco: {e}")
+            raise
 
-        from init_db import criar_dados_exemplo
         criar_dados_exemplo()
 
     app.run(host='0.0.0.0', port=port, debug=False)


### PR DESCRIPTION
## Summary
- add `ensure_schema` helper to apply migrations and validate schema
- verify schema in `main.py` before inserting sample data

## Testing
- `pytest`
- `python -m py_compile init_db.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68915e8be204832cb7c83adfa60352be