### PR TITLE
Set origem default for ordens de serviço and document

### DIFF
--- a/README_MELHORIAS.md
+++ b/README_MELHORIAS.md
@@ -20,6 +20,7 @@
 - Formulários completos para criação/edição
 - Status workflow implementado
 - Filtros avançados por mecânico, equipamento, etc.
+- Campo `origem` indica a fonte da OS: `manual` (padrão), `preventiva_automatica`, `preventiva_adhoc` ou `backlog`
 
 #### ✅ Estoque (`/js/pages/estoque.js`)
 - Controle de estoque com indicadores visuais

--- a/init_db.py
+++ b/init_db.py
@@ -581,12 +581,19 @@ def atualizar_dados_existentes():
                 'preventiva': 'Preventiva',
                 'corretiva': 'Corretiva Mecânica'
             }
-            
+
             tipo_nome = tipo_map.get(ordem.tipo, 'Corretiva Mecânica')
             tipo_manutencao = TipoManutencao.query.filter_by(nome=tipo_nome).first()
             if tipo_manutencao:
                 ordem.tipo_manutencao_id = tipo_manutencao.id
-    
+
+    # Definir origem padrão para ordens de serviço existentes
+    ordens_origem = OrdemServico.query.filter(OrdemServico.origem.is_(None)).all()
+    if ordens_origem:
+        print(f"📝 Definindo origem padrão em {len(ordens_origem)} ordens de serviço...")
+        for ordem in ordens_origem:
+            ordem.origem = 'manual'
+
     # Atualizar peças com grupo_item_id
     pecas = Peca.query.filter(Peca.grupo_item_id.is_(None)).all()
     if pecas:

--- a/src/models/ordem_servico.py
+++ b/src/models/ordem_servico.py
@@ -10,7 +10,11 @@ class OrdemServico(db.Model):
     mecanico_id = db.Column(db.Integer, db.ForeignKey('mecanicos.id'), nullable=True)
     tipo_manutencao_id = db.Column(db.Integer, db.ForeignKey('tipos_manutencao.id'), nullable=True)
     tipo = db.Column(db.String(20), nullable=True)  # Manter para compatibilidade, será removido após migração
-    origem = db.Column(db.String(30), nullable=True)  # preventiva_automatica, preventiva_adhoc, backlog, manual
+    origem = db.Column(
+        db.String(30),
+        nullable=True,
+        default='manual'
+    )  # Origem da OS: manual (padrão), preventiva_automatica, preventiva_adhoc, backlog
     prioridade = db.Column(db.String(20), nullable=False)  # baixa, media, alta, critica
     status = db.Column(db.String(30), nullable=False, default='aberta')  # aberta, em_execucao, aguardando_pecas, concluida, cancelada
     descricao_problema = db.Column(db.Text, nullable=False)


### PR DESCRIPTION
## Summary
- default OS origem to `manual` and explain allowed options
- assign default origem to existing records during init
- document origem field options in developer docs

## Testing
- `python -m py_compile src/models/ordem_servico.py init_db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68915fe8df20832ca0de80b4d4349155