### PR TITLE
Avoid duplicate table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Acesse: http://localhost:5000
 
 ## Banco de Dados e Migrações
 
-Este projeto utiliza **Alembic** para controle de versão do banco de dados.
+Este projeto utiliza **Alembic** para controle de versão do banco de dados. O
+schema deve ser gerenciado exclusivamente por ele (não use `db.create_all()`).
 
 - Para criar um novo banco local, execute:
 
@@ -78,8 +79,8 @@ python create_db.py
 
   O script aplicará todas as migrações pendentes.
 
-- Se você já possui um banco criado antes da introdução do Alembic,
-  sincronize o estado atual executando uma vez:
+- Se você já possui um banco com tabelas criadas manualmente ou por versões
+  anteriores, sincronize o estado atual executando uma vez:
 
 ```bash
 alembic stamp head

--- a/migrations/versions/bbd5a2b91492_initial_schema.py
+++ b/migrations/versions/bbd5a2b91492_initial_schema.py
@@ -39,18 +39,19 @@ def upgrade() -> None:
         sa.UniqueConstraint('codigo'),
         sa.UniqueConstraint('nome')
         )
-    op.create_table('grupos_item',
-    sa.Column('id', sa.Integer(), nullable=False),
-    sa.Column('nome', sa.String(length=100), nullable=False),
-    sa.Column('codigo', sa.String(length=20), nullable=False),
-    sa.Column('descricao', sa.Text(), nullable=True),
-    sa.Column('ativo', sa.Boolean(), nullable=True),
-    sa.Column('created_at', sa.DateTime(), nullable=True),
-    sa.Column('updated_at', sa.DateTime(), nullable=True),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('codigo'),
-    sa.UniqueConstraint('nome')
-    )
+    if not sa.inspect(op.get_bind()).has_table("grupos_item"):
+        op.create_table('grupos_item',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('nome', sa.String(length=100), nullable=False),
+        sa.Column('codigo', sa.String(length=20), nullable=False),
+        sa.Column('descricao', sa.Text(), nullable=True),
+        sa.Column('ativo', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('codigo'),
+        sa.UniqueConstraint('nome')
+        )
     op.create_table('mecanicos',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('nome_completo', sa.String(length=100), nullable=False),


### PR DESCRIPTION
## Summary
- prevent duplicate `grupos_item` table creation by checking for existing table in migration
- clarify Alembic is sole schema manager and mention `alembic stamp head` in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891614562fc832cbaa521038d96b04e