### PR TITLE
Load jQuery and Bootstrap before app scripts

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -222,6 +222,8 @@
     </div>
 
     <!-- Scripts -->
+    <script src="/js/vendor/jquery-3.7.1.min.js"></script>
+    <script src="/js/vendor/bootstrap.min.js"></script>
     <script src="/js/vendor/ag-grid-enterprise.min.js"></script>
     <script src="/js/ag-grid-config.js"></script>
     <script src="/js/test-data.js"></script>


### PR DESCRIPTION
## Summary
- Include jQuery and Bootstrap vendor scripts in `index.html` before other application scripts to avoid `$ is not defined` errors

## Testing
- `NODE_PATH=/tmp/jsdomtmp/node_modules node <<'NODE' ...`
- `pre-commit run --files src/static/index.html` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891f20b4748832c878df86bed5099e8