### PR TITLE
Expose page classes globally for navigation

### DIFF
--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -655,17 +655,6 @@ class EquipmentsPage {
     }
 }
 
-// Instância global para compatibilidade
-const equipmentsPage = new EquipmentsPage();
-
-// Inicialização quando o documento estiver pronto
-$(document).ready(() => {
-    // Se estivermos na página de equipamentos, inicializar
-    if (window.location.hash === '#equipamentos' || window.location.pathname.includes('equipamentos')) {
-        const container = document.querySelector('#main-content') || document.querySelector('.content');
-        if (container) {
-            equipmentsPage.render(container);
-        }
-    }
-});
+// Export the class to the global scope
+window.EquipmentsPage = EquipmentsPage;
 

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -592,6 +592,9 @@ class InventoryPage {
     }
 }
 
+// Expose the page class globally
+window.InventoryPage = InventoryPage;
+
 // Modal de Item de Estoque
 class InventoryItemModal {
     show(options) {

--- a/src/static/js/pages/mecanicos.js
+++ b/src/static/js/pages/mecanicos.js
@@ -835,6 +835,9 @@ class MechanicViewModal {
     }
 }
 
+// Expose the page class globally
+window.MechanicsPage = MechanicsPage;
+
 // Instância global
 let mechanicsPage = null;
 

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -681,14 +681,6 @@ class WorkOrdersPage {
     }
 }
 
-const workOrdersPage = new WorkOrdersPage();
-
-$(document).ready(() => {
-    if (window.location.hash === '#ordens-servico' || window.location.pathname.includes('ordens-servico')) {
-        const container = document.querySelector('#main-content') || document.querySelector('.content');
-        if (container) {
-            workOrdersPage.render(container);
-        }
-    }
-});
+// Expose the page class globally
+window.WorkOrdersPage = WorkOrdersPage;
 

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -634,14 +634,6 @@ class TiresPage {
     }
 }
 
-const tiresPage = new TiresPage();
-
-$(document).ready(() => {
-    if (window.location.hash === '#pneus' || window.location.pathname.includes('pneus')) {
-        const container = document.querySelector('#main-content') || document.querySelector('.content');
-        if (container) {
-            tiresPage.render(container);
-        }
-    }
-});
+// Expose the page class globally
+window.TiresPage = TiresPage;
 

--- a/src/static/js/pages/usuarios.js
+++ b/src/static/js/pages/usuarios.js
@@ -636,14 +636,6 @@ class UsersPage {
     }
 }
 
-const usersPage = new UsersPage();
-
-$(document).ready(() => {
-    if (window.location.hash === '#usuarios' || window.location.pathname.includes('usuarios')) {
-        const container = document.querySelector('#main-content') || document.querySelector('.content');
-        if (container) {
-            usersPage.render(container);
-        }
-    }
-});
+// Expose the page class globally
+window.UsersPage = UsersPage;
 


### PR DESCRIPTION
## Summary
- expose page classes globally for navigation-driven instantiation
- remove jQuery document-ready page initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891f35cd348832c9a0dd61d0878e55d