### PR TITLE
fix: ensure empty date cell renders correctly in tires grid

### DIFF
--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -457,7 +457,7 @@ const TIRES_GRID_INIT = () => {
                 field: "created_at",
                 minWidth: 150,
                 cellRenderer: (params) => {
-                    if (!params.value) return ";
+                    if (!params.value) return "";
                     return new Date(params.value).toLocaleString("pt-BR");
                 }
             }


### PR DESCRIPTION
## Summary
- handle missing date values in tires grid cell renderer by returning an empty string

## Testing
- `node --check src/static/js/pages/pneus.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f8150174832c998a76533e1cf5e5