### PR TITLE
Load AG Grid Enterprise bundle with embedded license

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -224,7 +224,7 @@
     <!-- Scripts -->
     <script src="/js/vendor/jquery-3.7.1.min.js"></script>
     <script src="/js/vendor/bootstrap.min.js"></script>
-    <script src="/js/vendor/ag-grid-enterprise.min.js"></script>
+    <script src="/static/js/vendor/ag-grid-enterprise.min.js"></script>
     <script src="/js/ag-grid-config.js"></script>
     <script src="/js/test-data.js"></script>
     <script src="/js/api.js"></script>

--- a/src/static/js/ag-grid-config.js
+++ b/src/static/js/ag-grid-config.js
@@ -1,10 +1,8 @@
 // Configuração global do AG-Grid
 class AGGridConfig {
     static init() {
-        // Configurar licença do AG-Grid Enterprise
-        // Substitua "SUA-LICENCA-AQUI" pela licença válida
-        agGrid.LicenseManager.setLicenseKey('SUA-LICENCA-AQUI');
-        
+        // Licença já incluída no bundle ag-grid-enterprise.min.js
+
         // Configurações globais padrão
         this.defaultGridOptions = {
             // Configurações de dados


### PR DESCRIPTION
## Summary
- load AG Grid Enterprise bundle from `/static/js/vendor`
- remove explicit `LicenseManager.setLicenseKey` call

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891fffd30b4832c951b854e2e4ae019