### PR TITLE
Load Tailwind CSS from CDN in index page

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -6,6 +6,7 @@
     <title>CMMS - Sistema de Manutenção</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
     <!-- Loading Screen -->


### PR DESCRIPTION
## Summary
- load Tailwind CSS from CDN before closing `head`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920da8fd2c832c91d1ddb4b981f1b1