### PR TITLE
fix: prevent missing modal errors

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -218,6 +218,36 @@
         <!-- Modals Container -->
         <div id="modals-container"></div>
 
+        <!-- Modal Ordens de Serviço -->
+        <div id="modal-ordem-servico" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div class="bg-white rounded-lg shadow-lg w-full max-w-3xl">
+                <div class="modal-header flex justify-between items-center p-4 border-b">
+                    <h3 class="modal-title text-lg font-semibold"></h3>
+                    <button type="button" class="modal-close" onclick="document.getElementById('modal-ordem-servico').classList.add('hidden')">&times;</button>
+                </div>
+                <div class="modal-body p-4 overflow-y-auto max-h-[70vh]"></div>
+                <div class="modal-footer flex justify-end space-x-2 p-4 border-t">
+                    <button type="button" class="btn btn-secondary" onclick="document.getElementById('modal-ordem-servico').classList.add('hidden')">Cancelar</button>
+                    <button type="button" class="btn btn-primary">Salvar</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Modal Preventiva -->
+        <div id="modal-preventiva" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div class="bg-white rounded-lg shadow-lg w-full max-w-3xl">
+                <div class="modal-header flex justify-between items-center p-4 border-b">
+                    <h3 class="modal-title text-lg font-semibold"></h3>
+                    <button type="button" class="modal-close" onclick="document.getElementById('modal-preventiva').classList.add('hidden')">&times;</button>
+                </div>
+                <div class="modal-body p-4 overflow-y-auto max-h-[70vh]"></div>
+                <div class="modal-footer flex justify-end space-x-2 p-4 border-t">
+                    <button type="button" class="btn btn-secondary" onclick="document.getElementById('modal-preventiva').classList.add('hidden')">Cancelar</button>
+                    <button type="button" class="btn btn-primary">Salvar</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Toast Notifications -->
         <div id="toast-container" class="toast-container"></div>
     </div>

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -70,14 +70,11 @@ const WORK_ORDERS_FORMDATA = (container) => {
 };
 
 const ADD_WORK_ORDER = async () => {
-    const modal = document.querySelector("#dynamicModal");
-    if (!modal) {
-        console.error("Modal container não encontrado");
-        return;
-    }
-    const modalBody = modal.querySelector(".modal-body");
-    const modalTitle = modal.querySelector(".modal-title");
-    const buttons = modal.querySelectorAll(".modal-footer button");
+    const modal = document.querySelector('#modal-ordem-servico');
+    if (!modal) return;
+    const modalBody = modal.querySelector('.modal-body');
+    const modalTitle = modal.querySelector('.modal-title');
+    const buttons = modal.querySelectorAll('.modal-footer button');
 
     await loadWorkOrdersRelatedData();
 
@@ -129,11 +126,13 @@ const ADD_WORK_ORDER = async () => {
     `;
 
     modalBody.innerHTML = template;
-    modalTitle.textContent = "Nova Ordem de Serviço";
+    modalTitle.textContent = 'Nova Ordem de Serviço';
 
-    $(modal).modal("show");
-    
-    $(buttons[0]).off("click").on("click", async () => {
+    modal.classList.remove('hidden');
+
+    buttons[1]?.addEventListener('click', () => modal.classList.add('hidden'));
+
+    $(buttons[0]).off('click').on('click', async () => {
         const formData = WORK_ORDERS_FORMDATA(modalBody);
         
         if (!formData.equipamento_id || !formData.tipo || !formData.prioridade || !formData.descricao_problema) {
@@ -157,25 +156,22 @@ const ADD_WORK_ORDER = async () => {
             }
 
             await SYNC_WORK_ORDERS_GRID_DATA();
-            $(modal).modal("hide");
-            Utils.showToast("Ordem de serviço criada com sucesso!", "success");
+            modal.classList.add('hidden');
+            Utils.showToast('Ordem de serviço criada com sucesso!', 'success');
         } catch (error) {
-            console.error("Erro ao criar ordem de serviço:", error);
-            Utils.showToast(error.message, "error");
+            console.error('Erro ao criar ordem de serviço:', error);
+            Utils.showToast(error.message, 'error');
         }
     });
 };
 
 const EDIT_WORK_ORDER = async (params) => {
     const rowData = params.node.data;
-    const modal = document.querySelector("#dynamicModal");
-    if (!modal) {
-        console.error("Modal container não encontrado");
-        return;
-    }
-    const modalBody = modal.querySelector(".modal-body");
-    const modalTitle = modal.querySelector(".modal-title");
-    const buttons = modal.querySelectorAll(".modal-footer button");
+    const modal = document.querySelector('#modal-ordem-servico');
+    if (!modal) return;
+    const modalBody = modal.querySelector('.modal-body');
+    const modalTitle = modal.querySelector('.modal-title');
+    const buttons = modal.querySelectorAll('.modal-footer button');
 
     await loadWorkOrdersRelatedData();
 
@@ -251,11 +247,13 @@ const EDIT_WORK_ORDER = async (params) => {
     `;
 
     modalBody.innerHTML = template;
-    modalTitle.textContent = "Editar Ordem de Serviço";
+    modalTitle.textContent = 'Editar Ordem de Serviço';
 
-    $(modal).modal("show");
-    
-    $(buttons[0]).off("click").on("click", async () => {
+    modal.classList.remove('hidden');
+
+    buttons[1]?.addEventListener('click', () => modal.classList.add('hidden'));
+
+    $(buttons[0]).off('click').on('click', async () => {
         const formData = WORK_ORDERS_FORMDATA(modalBody);
 
         try {
@@ -274,11 +272,11 @@ const EDIT_WORK_ORDER = async (params) => {
             }
 
             await SYNC_WORK_ORDERS_GRID_DATA();
-            $(modal).modal("hide");
-            Utils.showToast("Ordem de serviço atualizada com sucesso!", "success");
+            modal.classList.add('hidden');
+            Utils.showToast('Ordem de serviço atualizada com sucesso!', 'success');
         } catch (error) {
-            console.error("Erro ao atualizar ordem de serviço:", error);
-            Utils.showToast(error.message, "error");
+            console.error('Erro ao atualizar ordem de serviço:', error);
+            Utils.showToast(error.message, 'error');
         }
     });
 };

--- a/src/static/js/pages/preventivas.js
+++ b/src/static/js/pages/preventivas.js
@@ -487,6 +487,12 @@ class PreventivasPage {
 
     async showCreateModal() {
         try {
+            const container = document.querySelector('#modal-preventiva');
+            if (!container) {
+                console.error('Modal container não encontrado');
+                return;
+            }
+
             const content = `
                 <form id="planForm">
                     <div class="form-grid">
@@ -557,6 +563,8 @@ class PreventivasPage {
                 </form>
             `;
 
+            container.classList.remove('hidden');
+
             let overlay;
             overlay = Modal.show({
                 title: 'Novo Plano de Preventiva',
@@ -564,19 +572,29 @@ class PreventivasPage {
                 size: 'lg',
                 onClose: () => {
                     overlay.querySelector('#planForm')?.reset();
+                    container.classList.add('hidden');
                 }
             });
+            container.appendChild(overlay);
 
             const form = overlay.querySelector('#planForm');
             if (form) {
                 form.addEventListener('submit', async (e) => {
                     e.preventDefault();
                     await this.createPlan(new FormData(form));
-                    Modal.close(overlay, () => form.reset());
+                    Modal.close(overlay, () => {
+                        form.reset();
+                        container.classList.add('hidden');
+                    });
                 });
 
                 const cancelBtn = form.querySelector('[data-action="cancel"]');
-                cancelBtn?.addEventListener('click', () => Modal.close(overlay, () => form.reset()));
+                cancelBtn?.addEventListener('click', () => {
+                    Modal.close(overlay, () => {
+                        form.reset();
+                        container.classList.add('hidden');
+                    });
+                });
             }
 
         } catch (error) {


### PR DESCRIPTION
## Summary
- add hidden modal containers for work orders and preventive plans
- guard modal lookups in JS and toggle via Tailwind classes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68921eceb774832ca1353ac624b53990