### PR TITLE
feat: add central items library

### DIFF
--- a/README_MELHORIAS.md
+++ b/README_MELHORIAS.md
@@ -78,6 +78,9 @@
 - **Dados consistentes** entre módulos
 - **Relacionamentos** entre entidades
 
+### 6. Biblioteca central de itens
+- Biblioteca central de itens criada para normalização de estoque, ordens de serviço e planos preventivos
+
 ## 🛠️ Tecnologias Utilizadas
 
 ### Frontend

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -35,6 +35,7 @@ from src.models.analise_oleo import AnaliseOleo  # noqa: F401,E402
 from src.models.usuario import Usuario  # noqa: F401,E402
 from src.models.plano_preventiva import PlanoPreventiva  # noqa: F401,E402
 from src.models.backlog_item import BacklogItem  # noqa: F401,E402
+from src.models.item import Item  # noqa: F401,E402
 
 # Metadata for autogeneration support
 target_metadata = db.metadata

--- a/migrations/versions/0c280a00006a_create_tabela_itens.py
+++ b/migrations/versions/0c280a00006a_create_tabela_itens.py
@@ -1,0 +1,43 @@
+"""create tabela itens
+
+Revision ID: 0c280a00006a
+Revises: 3b76d7e3f1a2
+Create Date: 2025-08-05 18:51:11.715682
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0c280a00006a'
+down_revision: Union[str, Sequence[str], None] = '3b76d7e3f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'itens',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('codigo', sa.String(length=50), nullable=False),
+        sa.Column('nome', sa.String(length=255), nullable=False),
+        sa.Column('descricao', sa.Text(), nullable=True),
+        sa.Column('unidade_medida', sa.String(length=20), nullable=True),
+        sa.Column('grupo', sa.String(length=100), nullable=True),
+        sa.Column('fabricante', sa.String(length=100), nullable=True),
+        sa.Column('criado_em', sa.TIMESTAMP(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True),
+        sa.Column('atualizado_em', sa.TIMESTAMP(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('codigo')
+    )
+    op.create_index(op.f('ix_itens_id'), 'itens', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_itens_id'), table_name='itens')
+    op.drop_table('itens')

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ from src.routes.importacao import importacao_bp
 from src.routes.impressao import impressao_bp
 from src.routes.planos_preventiva import planos_preventiva_bp
 from src.routes.backlog import backlog_bp
+from src.routes.item_routes import item_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 
@@ -58,6 +59,7 @@ app.register_blueprint(importacao_bp, url_prefix='/api')
 app.register_blueprint(impressao_bp, url_prefix='/api')
 app.register_blueprint(planos_preventiva_bp, url_prefix='/api')
 app.register_blueprint(backlog_bp, url_prefix='/api')
+app.register_blueprint(item_bp, url_prefix="/api/itens")
 
 # Configurar banco de dados PostgreSQL
 database_url = os.environ.get("DATABASE_URL")
@@ -109,6 +111,7 @@ def api_index():
             "tipos_equipamento": "/api/tipos-equipamento",
             "tipos_manutencao": "/api/tipos-manutencao",
             "grupos_item": "/api/grupos-item",
+            "itens": "/api/itens",
             "analise_oleo": "/api/analise-oleo",
             "importacao": "/api/importacao/pecas",
             "impressao": "/api/ordens-servico/{id}/imprimir"

--- a/src/models/item.py
+++ b/src/models/item.py
@@ -1,0 +1,28 @@
+from src.db import db
+
+
+class Item(db.Model):
+    __tablename__ = "itens"
+
+    id = db.Column(db.Integer, primary_key=True, index=True)
+    codigo = db.Column(db.String(50), unique=True, nullable=False)
+    nome = db.Column(db.String(255), nullable=False)
+    descricao = db.Column(db.Text)
+    unidade_medida = db.Column(db.String(20))
+    grupo = db.Column(db.String(100))
+    fabricante = db.Column(db.String(100))
+    criado_em = db.Column(db.TIMESTAMP, default=db.func.now())
+    atualizado_em = db.Column(db.TIMESTAMP, default=db.func.now(), onupdate=db.func.now())
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "codigo": self.codigo,
+            "nome": self.nome,
+            "descricao": self.descricao,
+            "unidade_medida": self.unidade_medida,
+            "grupo": self.grupo,
+            "fabricante": self.fabricante,
+            "criado_em": self.criado_em.isoformat() if self.criado_em else None,
+            "atualizado_em": self.atualizado_em.isoformat() if self.atualizado_em else None,
+        }

--- a/src/routes/item_routes.py
+++ b/src/routes/item_routes.py
@@ -1,0 +1,87 @@
+from flask import Blueprint, request, jsonify
+from src.db import db
+from src.models.item import Item
+from src.utils.auth import token_required, supervisor_or_admin_required
+
+item_bp = Blueprint('item', __name__)
+
+
+@item_bp.route('', methods=['GET'])
+@token_required
+def get_items(current_user):
+    try:
+        items = Item.query.order_by(Item.nome).all()
+        return jsonify([item.to_dict() for item in items]), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@item_bp.route('/<int:item_id>', methods=['GET'])
+@token_required
+def get_item(current_user, item_id):
+    try:
+        item = Item.query.get_or_404(item_id)
+        return jsonify(item.to_dict()), 200
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@item_bp.route('', methods=['POST'])
+@token_required
+@supervisor_or_admin_required
+def create_item(current_user):
+    try:
+        data = request.get_json() or {}
+        if not data.get('codigo') or not data.get('nome'):
+            return jsonify({'error': 'Campos codigo e nome são obrigatórios'}), 400
+        if Item.query.filter_by(codigo=data['codigo']).first():
+            return jsonify({'error': 'Código já existe'}), 400
+        item = Item(
+            codigo=data['codigo'],
+            nome=data['nome'],
+            descricao=data.get('descricao'),
+            unidade_medida=data.get('unidade_medida'),
+            grupo=data.get('grupo'),
+            fabricante=data.get('fabricante')
+        )
+        db.session.add(item)
+        db.session.commit()
+        return jsonify({'message': 'Item criado com sucesso', 'item': item.to_dict()}), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+@item_bp.route('/<int:item_id>', methods=['PUT'])
+@token_required
+@supervisor_or_admin_required
+def update_item(current_user, item_id):
+    try:
+        item = Item.query.get_or_404(item_id)
+        data = request.get_json() or {}
+        if 'codigo' in data and data['codigo'] != item.codigo:
+            if Item.query.filter_by(codigo=data['codigo']).first():
+                return jsonify({'error': 'Código já existe'}), 400
+            item.codigo = data['codigo']
+        for field in ['nome', 'descricao', 'unidade_medida', 'grupo', 'fabricante']:
+            if field in data:
+                setattr(item, field, data[field])
+        db.session.commit()
+        return jsonify({'message': 'Item atualizado com sucesso', 'item': item.to_dict()}), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+@item_bp.route('/<int:item_id>', methods=['DELETE'])
+@token_required
+@supervisor_or_admin_required
+def delete_item(current_user, item_id):
+    try:
+        item = Item.query.get_or_404(item_id)
+        db.session.delete(item)
+        db.session.commit()
+        return jsonify({'message': 'Item excluído com sucesso'}), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500

--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -188,6 +188,14 @@ const API = {
         delete: (id) => api.delete(`/tipos-manutencao/${id}`)
     },
 
+    items: {
+        getAll: (params) => api.get('/itens', params),
+        get: (id) => api.get(`/itens/${id}`),
+        create: (data) => api.post('/itens', data),
+        update: (id, data) => api.put(`/itens/${id}`, data),
+        delete: (id) => api.delete(`/itens/${id}`)
+    },
+
     inventory: {
         getAll: (params) => api.get('/estoque/pecas', params),
         get: (id) => api.get(`/estoque/pecas/${id}`),

--- a/src/static/js/pages/movimentacoes.js
+++ b/src/static/js/pages/movimentacoes.js
@@ -7,6 +7,8 @@ class MovementsPage {
         this.searchTerm = '';
         this.typeFilter = '';
         this.dateFilter = '';
+        this.itemFilter = '';
+        this.items = [];
     }
 
     async render(container) {
@@ -31,6 +33,14 @@ class MovementsPage {
             this.data = [];
             this.filteredData = [];
             throw error;
+        }
+
+        try {
+            const itemsResponse = await API.items.getAll();
+            this.items = Array.isArray(itemsResponse) ? itemsResponse : (itemsResponse.data || []);
+        } catch (error) {
+            console.error('Erro ao carregar itens:', error);
+            this.items = [];
         }
     }
 
@@ -93,10 +103,17 @@ class MovementsPage {
                     </select>
                 </div>
                 <div class="filter-group">
+                    <label>Item</label>
+                    <select onchange="this.handleItemFilter(event)">
+                        <option value="">Todos</option>
+                        ${this.items.map(item => `<option value="${item.id}">${item.nome}</option>`).join('')}
+                    </select>
+                </div>
+                <div class="filter-group">
                     <label>Buscar</label>
                     <div class="search-input">
-                        <input type="text" 
-                               placeholder="Item, documento, responsável..." 
+                        <input type="text"
+                               placeholder="Item, documento, responsável..."
                                value="${this.searchTerm}"
                                onkeyup="this.handleSearch(event)">
                         <i class="icon-search"></i>
@@ -317,6 +334,11 @@ class MovementsPage {
         this.applyFilters();
     }
 
+    handleItemFilter(event) {
+        this.itemFilter = event.target.value;
+        this.applyFilters();
+    }
+
     applyFilters() {
         this.filteredData = this.data.filter(item => {
             const searchMatch = !this.searchTerm || 
@@ -351,7 +373,11 @@ class MovementsPage {
                 }
             }
 
-            return searchMatch && typeMatch && dateMatch;
+            const itemMatch = !this.itemFilter ||
+                item.item_id === parseInt(this.itemFilter) ||
+                item.peca_id === parseInt(this.itemFilter);
+
+            return searchMatch && typeMatch && dateMatch && itemMatch;
         });
 
         this.currentPage = 1;
@@ -362,6 +388,7 @@ class MovementsPage {
         this.searchTerm = '';
         this.typeFilter = '';
         this.dateFilter = '';
+        this.itemFilter = '';
         this.filteredData = [...this.data];
         this.currentPage = 1;
         this.updateContent();


### PR DESCRIPTION
## Summary
- add Item model and CRUD routes
- expose items API and filter in movements page
- document central item library in README_MELHORIAS

## Testing
- `pytest`
- `alembic upgrade head` (fails: CircularDependencyError)
- `alembic revision --autogenerate -m "create tabela itens"` (fails: Target database is not up to date)
- `alembic revision -m "create tabela itens"`
- `alembic upgrade head` (fails: Multiple head revisions)


------
https://chatgpt.com/codex/tasks/task_e_68924dd2edbc832cb53edc8524e4127d