### PR TITLE
Fix multiple Alembic head revisions

### DIFF
--- a/migrations/versions/e266aade2cf3_merge_heads.py
+++ b/migrations/versions/e266aade2cf3_merge_heads.py
@@ -1,0 +1,22 @@
+"""merge heads 0c280a00006a and 1f2ad21e0c25
+
+Revision ID: e266aade2cf3
+Revises: 0c280a00006a, 1f2ad21e0c25
+Create Date: 2023-08-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e266aade2cf3'
+down_revision: Union[str, Sequence[str], None] = ('0c280a00006a', '1f2ad21e0c25')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add merge migration to consolidate divergent Alembic heads

## Testing
- `alembic upgrade head` *(fails: CircularDependencyError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689253ed1cd0832cbc7f7cf28154e71e