### PR TITLE
Handle invalid Alembic revisions

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -28,6 +28,7 @@ from src.models.plano_preventiva import PlanoPreventiva
 from src.models.backlog_item import BacklogItem
 from alembic import command
 from alembic.config import Config
+from alembic.util import CommandError
 
 def create_database():
     """Criar banco de dados com todas as tabelas."""
@@ -53,7 +54,15 @@ def create_database():
 
     with app.app_context():
         print("🔧 Aplicando migrações...")
-        command.upgrade(alembic_cfg, 'head')
+        try:
+            command.upgrade(alembic_cfg, 'head')
+        except CommandError as e:
+            if "Can't locate revision identified by" in str(e):
+                print(f"⚠️  Revisão inválida detectada ({e}). Resetando para base...")
+                command.stamp(alembic_cfg, 'base')
+                command.upgrade(alembic_cfg, 'head')
+            else:
+                raise
         print(f"✅ Banco de dados criado/atualizado: {db_path}")
 
         # Verificar tabelas existentes

--- a/init_db.py
+++ b/init_db.py
@@ -54,9 +54,20 @@ def run_migrations():
     """Apply database migrations."""
     from alembic import command
     from alembic.config import Config
+    from alembic.util import CommandError
 
     alembic_cfg = Config(os.path.join(current_dir, 'alembic.ini'))
-    command.upgrade(alembic_cfg, 'head')
+
+    try:
+        command.upgrade(alembic_cfg, 'head')
+    except CommandError as e:
+        # Corrige versões inválidas que possam estar registradas no banco
+        if "Can't locate revision identified by" in str(e):
+            print(f"⚠️  Revisão inválida detectada ({e}). Resetando para base...")
+            command.stamp(alembic_cfg, 'base')
+            command.upgrade(alembic_cfg, 'head')
+        else:
+            raise
 
 def ensure_schema():
     """Garantir que o esquema do banco esteja atualizado antes de manipular dados."""


### PR DESCRIPTION
## Summary
- handle invalid alembic revisions by stamping base then re-running migrations
- add same revision reset logic to standalone DB creation script

## Testing
- `pytest -q`
- `python create_db.py`

------
https://chatgpt.com/codex/tasks/task_e_689274e04b40832c9a37bcc95ee4c022