### PR TITLE
Fix Alembic revision error by cleaning version table

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -29,6 +29,7 @@ from src.models.backlog_item import BacklogItem
 from alembic import command
 from alembic.config import Config
 from alembic.util import CommandError
+from sqlalchemy import text
 
 def create_database():
     """Criar banco de dados com todas as tabelas."""
@@ -59,6 +60,9 @@ def create_database():
         except CommandError as e:
             if "Can't locate revision identified by" in str(e):
                 print(f"⚠️  Revisão inválida detectada ({e}). Resetando para base...")
+                # Remover tabela de controle de versões antes de reconfigurar
+                with db.engine.begin() as conn:
+                    conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
                 command.stamp(alembic_cfg, 'base')
                 command.upgrade(alembic_cfg, 'head')
             else:

--- a/init_db.py
+++ b/init_db.py
@@ -55,6 +55,7 @@ def run_migrations():
     from alembic import command
     from alembic.config import Config
     from alembic.util import CommandError
+    from sqlalchemy import text
 
     alembic_cfg = Config(os.path.join(current_dir, 'alembic.ini'))
 
@@ -64,6 +65,9 @@ def run_migrations():
         # Corrige versões inválidas que possam estar registradas no banco
         if "Can't locate revision identified by" in str(e):
             print(f"⚠️  Revisão inválida detectada ({e}). Resetando para base...")
+            # Remover tabela de controle de versões para evitar conflitos
+            with db.engine.begin() as conn:
+                conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
             command.stamp(alembic_cfg, 'base')
             command.upgrade(alembic_cfg, 'head')
         else:


### PR DESCRIPTION
## Summary
- Handle invalid Alembic revisions by dropping the version table before stamping and reapplying migrations
- Apply the same recovery logic to the SQLite database setup script

## Testing
- `python -m py_compile init_db.py create_db.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68927cc78b94832cbe054dcea2a03c7e