### PR TITLE
Fix Alembic multiple head revisions

### DIFF
--- a/migrations/versions/c88aaf0732bc_create_tabela_itens.py
+++ b/migrations/versions/c88aaf0732bc_create_tabela_itens.py
@@ -1,7 +1,7 @@
 """create tabela itens
 
 Revision ID: c88aaf0732bc
-Revises: 
+Revises: e5963818dfc8
 Create Date: 2025-08-05 21:11:44.710822
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision: str = 'c88aaf0732bc'
-down_revision: Union[str, Sequence[str], None] = None
+down_revision: Union[str, Sequence[str], None] = 'e5963818dfc8'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- Link `c88aaf0732bc` migration to previous `e5963818dfc8` revision to eliminate multiple heads

## Testing
- `alembic upgrade head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689280ed5dc8832c81a15c2c5ebb3d7d