### PR TITLE
Prevent duplicate creation of itens table in initial migration

### DIFF
--- a/migrations/versions/e5963818dfc8_create_itens.py
+++ b/migrations/versions/e5963818dfc8_create_itens.py
@@ -7,23 +7,38 @@ depends_on = None
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 def upgrade():
-    op.create_table('itens',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('numero_item', sa.String(length=50), nullable=False),
-        sa.Column('descricao_item', sa.Text(), nullable=False),
-        sa.Column('grupo_itens', sa.String(length=100), nullable=True),
-        sa.Column('unidade_medida', sa.String(length=20), nullable=True),
-        sa.Column('ultimo_preco_avaliacao', sa.Numeric(12, 2), nullable=True),
-        sa.Column('ultimo_preco_compra', sa.Numeric(12, 2), nullable=True),
-        sa.Column('estoque_baixo', sa.Boolean(), nullable=True),
-        sa.Column('data_registro', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=True),
-        sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('numero_item')
-    )
+    """Create itens table if it does not already exist."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table("itens"):
+        op.create_table(
+            "itens",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("numero_item", sa.String(length=50), nullable=False),
+            sa.Column("descricao_item", sa.Text(), nullable=False),
+            sa.Column("grupo_itens", sa.String(length=100), nullable=True),
+            sa.Column("unidade_medida", sa.String(length=20), nullable=True),
+            sa.Column("ultimo_preco_avaliacao", sa.Numeric(12, 2), nullable=True),
+            sa.Column("ultimo_preco_compra", sa.Numeric(12, 2), nullable=True),
+            sa.Column("estoque_baixo", sa.Boolean(), nullable=True),
+            sa.Column(
+                "data_registro",
+                sa.TIMESTAMP(),
+                server_default=sa.text("now()"),
+                nullable=True,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("numero_item"),
+        )
 
 
 def downgrade():
-    op.drop_table('itens')
+    """Drop itens table if it exists."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if inspector.has_table("itens"):
+        op.drop_table("itens")


### PR DESCRIPTION
## Summary
- avoid failing when `itens` table already exists during initial migration

## Testing
- `alembic upgrade head`

------
https://chatgpt.com/codex/tasks/task_e_689285610ba4832c9ee065eb4cf0a972