### PR TITLE
Fix inventory data property

### DIFF
--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -34,7 +34,7 @@ class InventoryPage {
     async loadData() {
         try {
             const response = await API.inventory.getAll();
-            this.data = Array.isArray(response) ? response : (response.data || []);
+            this.data = response.pecas || response.data || [];
         } catch (error) {
             console.error('Erro ao carregar dados:', error);
             this.data = [];


### PR DESCRIPTION
## Summary
- ensure inventory page uses `response.pecas` or fallback to `response.data` when loading items

## Testing
- `pytest`
- Node script exercising `InventoryPage.loadData` and verifying items are loaded


------
https://chatgpt.com/codex/tasks/task_e_689296f51600832cb1a7f7003518eaf0