### PR TITLE
Registrar rotas de itens alinhadas ao modelo

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from src.routes.usuarios import usuarios_bp
 from src.routes.tipos_equipamento import tipos_equipamento_bp
 from src.routes.tipos_manutencao import tipos_manutencao_bp
 from src.routes.grupos_item import grupos_item_bp
+from src.routes.item_routes import item_bp
 from src.routes.analise_oleo import analise_oleo_bp
 from src.routes.importacao import importacao_bp
 from src.routes.impressao import impressao_bp
@@ -53,6 +54,7 @@ app.register_blueprint(usuarios_bp, url_prefix='/api')
 app.register_blueprint(tipos_equipamento_bp, url_prefix='/api')
 app.register_blueprint(tipos_manutencao_bp, url_prefix='/api')
 app.register_blueprint(grupos_item_bp, url_prefix='/api')
+app.register_blueprint(item_bp, url_prefix='/api/itens')
 app.register_blueprint(analise_oleo_bp, url_prefix='/api')
 app.register_blueprint(importacao_bp, url_prefix='/api')
 app.register_blueprint(impressao_bp, url_prefix='/api')
@@ -109,6 +111,7 @@ def api_index():
             "tipos_equipamento": "/api/tipos-equipamento",
             "tipos_manutencao": "/api/tipos-manutencao",
             "grupos_item": "/api/grupos-item",
+            "itens": "/api/itens",
             "analise_oleo": "/api/analise-oleo",
             "importacao": "/api/importacao/pecas",
             "impressao": "/api/ordens-servico/{id}/imprimir"

--- a/src/routes/item_routes.py
+++ b/src/routes/item_routes.py
@@ -1,61 +1,107 @@
-
-from flask import Blueprint, request, jsonify
-from src.db import db_session
+from flask import Blueprint, jsonify, request
+from src.db import db
 from src.models.item import Item
+
 
 item_bp = Blueprint('item_bp', __name__)
 
+
 @item_bp.route('/', methods=['GET'])
 def listar_itens():
-    itens = db_session.query(Item).all()
-    return jsonify([{
-        'id': i.id,
-        'codigo': i.codigo,
-        'nome': i.nome,
-        'descricao': i.descricao,
-        'unidade_medida': i.unidade_medida,
-        'grupo': i.grupo,
-        'fabricante': i.fabricante
-    } for i in itens])
+    itens = db.session.query(Item).all()
+    return jsonify([
+        {
+            'id': i.id,
+            'numero_item': i.numero_item,
+            'descricao_item': i.descricao_item,
+            'grupo_itens': i.grupo_itens,
+            'unidade_medida': i.unidade_medida,
+            'ultimo_preco_avaliacao': float(i.ultimo_preco_avaliacao)
+            if i.ultimo_preco_avaliacao is not None
+            else None,
+            'ultimo_preco_compra': float(i.ultimo_preco_compra)
+            if i.ultimo_preco_compra is not None
+            else None,
+            'estoque_baixo': i.estoque_baixo,
+        }
+        for i in itens
+    ])
+
 
 @item_bp.route('/', methods=['POST'])
 def criar_item():
-    data = request.json
+    data = request.get_json() or {}
+
+    numero_item = data.get('numero_item')
+    descricao_item = data.get('descricao_item')
+    if not numero_item or not descricao_item:
+        return (
+            jsonify(
+                {'message': 'Campos numero_item e descricao_item são obrigatórios'}
+            ),
+            400,
+        )
+
+    if db.session.query(Item).filter_by(numero_item=numero_item).first():
+        return jsonify({'message': 'Número do item já existe'}), 400
+
     item = Item(
-        codigo=data['codigo'],
-        nome=data['nome'],
-        descricao=data.get('descricao'),
+        numero_item=numero_item,
+        descricao_item=descricao_item,
+        grupo_itens=data.get('grupo_itens'),
         unidade_medida=data.get('unidade_medida'),
-        grupo=data.get('grupo'),
-        fabricante=data.get('fabricante')
+        ultimo_preco_avaliacao=data.get('ultimo_preco_avaliacao'),
+        ultimo_preco_compra=data.get('ultimo_preco_compra'),
+        estoque_baixo=data.get('estoque_baixo', False),
     )
-    db_session.add(item)
-    db_session.commit()
+
+    db.session.add(item)
+    db.session.commit()
     return jsonify({'message': 'Item criado com sucesso.'}), 201
+
 
 @item_bp.route('/<int:item_id>', methods=['PUT'])
 def atualizar_item(item_id):
-    item = db_session.query(Item).get(item_id)
+    item = db.session.query(Item).get(item_id)
     if not item:
         return jsonify({'message': 'Item não encontrado'}), 404
 
-    data = request.json
-    item.codigo = data.get('codigo', item.codigo)
-    item.nome = data.get('nome', item.nome)
-    item.descricao = data.get('descricao', item.descricao)
-    item.unidade_medida = data.get('unidade_medida', item.unidade_medida)
-    item.grupo = data.get('grupo', item.grupo)
-    item.fabricante = data.get('fabricante', item.fabricante)
+    data = request.get_json() or {}
 
-    db_session.commit()
+    if 'numero_item' in data:
+        numero_item = data['numero_item']
+        if (
+            db.session.query(Item)
+            .filter(Item.numero_item == numero_item, Item.id != item_id)
+            .first()
+        ):
+            return jsonify({'message': 'Número do item já existe'}), 400
+        item.numero_item = numero_item
+
+    if 'descricao_item' in data:
+        item.descricao_item = data['descricao_item']
+    if 'grupo_itens' in data:
+        item.grupo_itens = data['grupo_itens']
+    if 'unidade_medida' in data:
+        item.unidade_medida = data['unidade_medida']
+    if 'ultimo_preco_avaliacao' in data:
+        item.ultimo_preco_avaliacao = data['ultimo_preco_avaliacao']
+    if 'ultimo_preco_compra' in data:
+        item.ultimo_preco_compra = data['ultimo_preco_compra']
+    if 'estoque_baixo' in data:
+        item.estoque_baixo = data['estoque_baixo']
+
+    db.session.commit()
     return jsonify({'message': 'Item atualizado com sucesso'})
+
 
 @item_bp.route('/<int:item_id>', methods=['DELETE'])
 def deletar_item(item_id):
-    item = db_session.query(Item).get(item_id)
+    item = db.session.query(Item).get(item_id)
     if not item:
         return jsonify({'message': 'Item não encontrado'}), 404
 
-    db_session.delete(item)
-    db_session.commit()
+    db.session.delete(item)
+    db.session.commit()
     return jsonify({'message': 'Item deletado com sucesso'})
+


### PR DESCRIPTION
## Summary
- Adiciona blueprint de itens em `main.py` com prefixo `/api/itens`
- Reimplementa rotas de itens usando `db.session` e campos do modelo `Item`
- Valida criação/edição e retorna JSON compatível com o frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892b69e66c8832cac5e57968a39794f