### PR TITLE
Add responsive chart container styling

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -1833,6 +1833,19 @@ body {
     cursor: not-allowed;
 }
 
+/* === CHART CONTAINERS === */
+.chart-container {
+    width: 100%;
+    min-height: 300px;
+    margin: 1rem 0;
+}
+
+@media (max-width: 768px) {
+    .chart-container {
+        min-height: 250px;
+    }
+}
+
 /* === CHART ENHANCEMENTS === */
 .ag-theme-alpine .ag-chart-wrapper {
     border: 1px solid var(--gray-200);

--- a/src/static/js/pages/dashboard.js
+++ b/src/static/js/pages/dashboard.js
@@ -184,7 +184,7 @@ class DashboardPage {
                         </h3>
                     </div>
                     <div class="card-body">
-                        <div id="os-status-chart"></div>
+                        <div id="os-status-chart" class="chart-container"></div>
                     </div>
                 </div>
 
@@ -197,7 +197,7 @@ class DashboardPage {
                         </h3>
                     </div>
                     <div class="card-body">
-                        <div id="maintenance-types-chart"></div>
+                        <div id="maintenance-types-chart" class="chart-container"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- style chart containers with full width, minimum height, and spacing
- make chart containers responsive on small screens
- apply chart container class to dashboard charts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68935e4c36c4832c958451be6db6c7ec