### PR TITLE
feat: add item group select

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -288,7 +288,7 @@
     <form id="item-form">
         <input type="text" name="numero_item" placeholder="Número do Item" required>
         <input type="text" name="descricao_item" placeholder="Descrição" required>
-        <input type="text" name="grupo_itens" placeholder="Grupo do Item">
+        <select id="grupo_itens" name="grupo_itens"></select>
         <input type="text" name="unidade_medida" placeholder="Unidade de Medida">
         <input type="number" step="0.01" name="ultimo_preco_avaliacao" placeholder="Último Preço Avaliação">
         <input type="number" step="0.01" name="ultimo_preco_compra" placeholder="Último Preço Compra">

--- a/src/static/js/pages/itens.js
+++ b/src/static/js/pages/itens.js
@@ -4,6 +4,24 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const form = document.getElementById("item-form");
     const tabela = document.getElementById("tabela-itens");
+    const grupoSelect = document.getElementById("grupo_itens");
+
+    function carregarGrupos() {
+        if (!grupoSelect) return;
+        API.itemGroups.getAll()
+            .then(response => {
+                const grupos = response.grupos_item || [];
+                grupoSelect.innerHTML = '<option value="">Selecione um grupo</option>';
+                grupos.forEach(grupo => {
+                    const option = document.createElement('option');
+                    option.value = grupo.nome;
+                    option.textContent = grupo.nome;
+                    option.dataset.id = grupo.id;
+                    grupoSelect.appendChild(option);
+                });
+            })
+            .catch(err => console.error('Erro ao carregar grupos de item:', err));
+    }
 
     function carregarItens() {
         fetch(apiUrl)
@@ -54,5 +72,6 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
+    carregarGrupos();
     carregarItens();
 });


### PR DESCRIPTION
## Summary
- replace item group text input with select
- load groups from API and use selection on submission

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689364b1f558832c8f38ecbf1b28130b