### PR TITLE
Link pneus to itens via item_id

### DIFF
--- a/migrations/versions/154126f4fb1b_add_item_id_to_pneus.py
+++ b/migrations/versions/154126f4fb1b_add_item_id_to_pneus.py
@@ -1,0 +1,41 @@
+"""add item_id to pneus
+
+Revision ID: 154126f4fb1b
+Revises: c88aaf0732bc
+Create Date: 2025-08-06 14:48:22.219084
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = '154126f4fb1b'
+down_revision: Union[str, Sequence[str], None] = 'c88aaf0732bc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if 'pneus' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('pneus')]
+        if 'item_id' not in columns:
+            op.add_column('pneus', sa.Column('item_id', sa.Integer(), nullable=False))
+            op.create_foreign_key('fk_pneus_item_id_itens', 'pneus', 'itens', ['item_id'], ['id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if 'pneus' in inspector.get_table_names():
+        columns = [col['name'] for col in inspector.get_columns('pneus')]
+        if 'item_id' in columns:
+            op.drop_constraint('fk_pneus_item_id_itens', 'pneus', type_='foreignkey')
+            op.drop_column('pneus', 'item_id')

--- a/src/models/pneu.py
+++ b/src/models/pneu.py
@@ -14,6 +14,7 @@ class Pneu(db.Model):
     tipo = db.Column(db.String(20), nullable=False)  # novo, recapado
     status = db.Column(db.String(20), nullable=False, default='estoque')  # estoque, em_uso, descarte, recapagem
     equipamento_id = db.Column(db.Integer, db.ForeignKey('equipamentos.id'), nullable=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('itens.id'), nullable=False)
     posicao = db.Column(db.String(20), nullable=True)  # dianteiro_esquerdo, traseiro_direito, etc.
     data_compra = db.Column(db.Date, nullable=False)
     valor_compra = db.Column(db.Float, nullable=True)
@@ -30,6 +31,7 @@ class Pneu(db.Model):
     observacoes = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    item = db.relationship('Item')
     
     def to_dict(self):
         km_rodados = 0
@@ -51,6 +53,7 @@ class Pneu(db.Model):
             'tipo': self.tipo,
             'status': self.status,
             'equipamento_id': self.equipamento_id,
+            'item_id': self.item_id,
             'posicao': self.posicao,
             'data_compra': self.data_compra.isoformat() if self.data_compra else None,
             'valor_compra': self.valor_compra,
@@ -67,6 +70,13 @@ class Pneu(db.Model):
             'data_descarte': self.data_descarte.isoformat() if self.data_descarte else None,
             'motivo_descarte': self.motivo_descarte,
             'observacoes': self.observacoes,
+            'item': {
+                'id': self.item.id,
+                'numero_item': self.item.numero_item,
+                'descricao_item': self.item.descricao_item,
+                'grupo_itens': self.item.grupo_itens,
+                'unidade_medida': self.item.unidade_medida
+            } if self.item else None,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None
         }


### PR DESCRIPTION
## Summary
- link pneus to itens with new item_id column and nested serialization
- validate and handle item_id on tire creation and update endpoints
- expose item selection in tire frontend forms

## Testing
- `python -m py_compile src/models/pneu.py src/routes/pneus.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68936a217864832c8203cc5d48eb36bd