### PR TITLE
Oculta itens de grupos no menu e exibe ao expandir

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -465,6 +465,14 @@ body {
     padding-left: 1rem;
 }
 
+.nav-group .nav-group-items {
+    display: none;
+}
+
+.nav-group.expanded .nav-group-items {
+    display: block;
+}
+
 /* === MAIN CONTENT === */
 .main-content {
     margin-left: var(--sidebar-width);


### PR DESCRIPTION
## Summary
- Esconde submenus dos grupos de navegação por padrão
- Exibe submenus quando o grupo recebe a classe `expanded`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68939220b3c4832cb7828b09e139a834