### PR TITLE
Handle auth errors without reload and init navigation after login

### DIFF
--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -43,7 +43,12 @@ class ApiClient {
             // Desloga se o token estiver inválido ou expirado
             if (response.status === 401) {
                 this.setToken(null);
-                window.location.reload();
+                if (typeof auth !== 'undefined' && typeof auth.logout === 'function') {
+                    // Evita chamada ao servidor durante logout forçado
+                    await auth.logout(true);
+                } else if (typeof app !== 'undefined' && typeof app.showLogin === 'function') {
+                    app.showLogin();
+                }
                 return;
             }
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -107,6 +107,11 @@ class CMSApp {
                 this.appContainer.style.display = 'grid';
             }
 
+            // Inicializar gerenciador de navegação após autenticação
+            if (!window.navigation) {
+                window.navigation = new NavigationManager();
+            }
+
             // Carregar notificações
             await this.loadNotifications();
 
@@ -198,6 +203,7 @@ class CMSApp {
         // Callback de logout
         auth.onLogout(() => {
             console.log('Logout realizado');
+            window.navigation = null;
             this.showLogin();
         });
     }

--- a/src/static/js/auth.js
+++ b/src/static/js/auth.js
@@ -50,20 +50,22 @@ class AuthManager {
     }
 
     // Fazer logout
-    async logout() {
+    async logout(skipServer = false) {
         try {
-            // Tentar fazer logout no servidor
-            await API.auth.logout();
+            // Tentar fazer logout no servidor, caso seja uma ação voluntária
+            if (!skipServer) {
+                await API.auth.logout();
+            }
         } catch (error) {
             console.error('Erro no logout:', error);
         } finally {
             // Limpar dados locais
             this.token = null;
             this.currentUser = null;
-            
+
             // Remover token
             api.setToken(null);
-            
+
             // Executar callbacks de logout
             this.logoutCallbacks.forEach(callback => callback());
         }

--- a/src/static/js/navigation.js
+++ b/src/static/js/navigation.js
@@ -341,10 +341,6 @@ class NavigationManager {
     }
 }
 
-// Instância global do gerenciador de navegação
-const navigation = new NavigationManager();
-
-// Exportar para uso global
-window.navigation = navigation;
+// Exportar classe para uso global
 window.NavigationManager = NavigationManager;
 


### PR DESCRIPTION
## Summary
- Avoid page reload on unauthorized API responses and redirect to login instead
- Add optional skipServer flag to auth logout
- Instantiate navigation only after successful authentication

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689396a86818832c8b6651d68216f35f