### PR TITLE
fix: prevent sidebar toggle event bubbling

### DIFF
--- a/src/static/js/navigation.js
+++ b/src/static/js/navigation.js
@@ -57,7 +57,8 @@ class NavigationManager {
     setupMenuToggle() {
         if (!this.menuToggle) return;
 
-        this.menuToggle.addEventListener('click', () => {
+        this.menuToggle.addEventListener('click', (e) => {
+            e.stopPropagation();
             this.isSidebarOpen = !this.isSidebarOpen;
             this.updateSidebar();
         });


### PR DESCRIPTION
## Summary
- stop menu toggle click event from bubbling to document
- ensure sidebar state toggles cleanly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68939e52bbb4832c9052675e140b44f2