### PR TITLE
refactor: delegate user menu to React component

### DIFF
--- a/src/static/js/navigation.js
+++ b/src/static/js/navigation.js
@@ -32,7 +32,6 @@ class NavigationManager {
         // Event listeners
         this.setupSidebarEvents();
         this.setupMenuToggle();
-        this.setupUserMenu();
 
         // Carregar página inicial
         this.navigateTo('dashboard');
@@ -78,48 +77,6 @@ class NavigationManager {
         } else {
             this.sidebar.classList.remove('open');
             this.sidebar.classList.toggle('closed', !this.isSidebarOpen);
-        }
-    }
-
-    setupUserMenu() {
-        const userBtn = document.querySelector('.user-btn');
-        const userDropdown = document.querySelector('.user-dropdown');
-
-        if (userBtn && userDropdown) {
-            userBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                userDropdown.classList.toggle('show');
-            });
-
-            // Fechar dropdown ao clicar fora do menu
-            document.addEventListener('click', (e) => {
-                if (!userDropdown.contains(e.target) && !userBtn.contains(e.target)) {
-                    userDropdown.classList.remove('show');
-                }
-            });
-
-            // Event listeners do dropdown
-            userDropdown.addEventListener('click', (e) => {
-                const link = e.target.closest('a');
-                if (link) {
-                    e.preventDefault();
-                    const action = link.id;
-                    
-                    switch (action) {
-                        case 'user-profile':
-                            this.showUserProfile();
-                            break;
-                        case 'user-settings':
-                            this.showUserSettings();
-                            break;
-                        case 'logout':
-                            this.handleLogout();
-                            break;
-                    }
-                    
-                    userDropdown.classList.remove('show');
-                }
-            });
         }
     }
 

--- a/src/static/js/userMenu.js
+++ b/src/static/js/userMenu.js
@@ -15,8 +15,8 @@ function UserMenu() {
   }, []);
 
   return React.createElement(
-    React.Fragment,
-    null,
+    'div',
+    { ref: menuRef },
     React.createElement(
       'button',
       {
@@ -35,20 +35,44 @@ function UserMenu() {
       { className: `user-dropdown${isUserMenuOpen ? ' show' : ''}` },
       React.createElement(
         'a',
-        { href: '#', id: 'user-profile' },
+        {
+          href: '#',
+          id: 'user-profile',
+          onClick: (e) => {
+            e.preventDefault();
+            window.navigation && window.navigation.showUserProfile();
+            setIsUserMenuOpen(false);
+          }
+        },
         React.createElement('i', { className: 'fas fa-user' }),
         ' Perfil'
       ),
       React.createElement(
         'a',
-        { href: '#', id: 'user-settings' },
+        {
+          href: '#',
+          id: 'user-settings',
+          onClick: (e) => {
+            e.preventDefault();
+            window.navigation && window.navigation.showUserSettings();
+            setIsUserMenuOpen(false);
+          }
+        },
         React.createElement('i', { className: 'fas fa-cog' }),
         ' Configurações'
       ),
       React.createElement('hr', null),
       React.createElement(
         'a',
-        { href: '#', id: 'logout' },
+        {
+          href: '#',
+          id: 'logout',
+          onClick: (e) => {
+            e.preventDefault();
+            window.navigation && window.navigation.handleLogout();
+            setIsUserMenuOpen(false);
+          }
+        },
         React.createElement('i', { className: 'fas fa-sign-out-alt' }),
         ' Sair'
       )


### PR DESCRIPTION
## Summary
- remove DOM-based setupUserMenu and delegate to React UserMenu component
- handle profile, settings and logout actions through React

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893a183ea1c832c82a1e2ea08941e02