### PR TITLE
fix: update API base URL

### DIFF
--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -1,5 +1,5 @@
 // Configuração da API
-const API_BASE_URL = window.location.origin + '/api';
+const API_BASE_URL = 'https://cmmssistema-production.up.railway.app/api';
 
 // Cliente HTTP para comunicação com a API
 class ApiClient {


### PR DESCRIPTION
## Summary
- point API client to the production API base URL

## Testing
- `pytest`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a7556d7c832cbe6bb0aca1ded172