### PR TITLE
fix: restore frontend menus and prevent mixed content

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -245,6 +245,8 @@
     <script src="/js/vendor/bootstrap.min.js"></script>
     <script src="/static/js/vendor/ag-grid-enterprise.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/ag-charts-community/dist/ag-charts-community.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="/js/ag-grid-config.js"></script>
     <script src="/js/test-data.js"></script>
     <script src="/js/api.js"></script>
@@ -252,8 +254,6 @@
     <script src="/js/utils.js"></script>
     <script src="/js/auth.js"></script>
     <script src="/js/navigation.js"></script>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="/js/userMenu.js"></script>
     <script src="/js/components.js"></script>
     <script src="/js/pages/dashboard.js"></script>

--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -1,5 +1,6 @@
 // Configuração da API
-const API_BASE_URL = 'https://cmmssistema-production.up.railway.app/api';
+// Usa o mesmo protocolo da página atual para evitar erros de mixed content
+const API_BASE_URL = `${window.location.protocol}//cmmssistema-production.up.railway.app/api`;
 
 // Cliente HTTP para comunicação com a API
 class ApiClient {


### PR DESCRIPTION
## Summary
- load React before navigation code so sidebar, submenus, and user menu work again
- build API base URL with current protocol to avoid mixed content errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ae4584e4832c9f2f9c2e4054862b