### PR TITLE
fix: isolate React hooks in navigation scripts

### DIFF
--- a/src/static/js/navigation.js
+++ b/src/static/js/navigation.js
@@ -1,4 +1,5 @@
 // Gerenciador de navegação
+(() => {
 const { useState, useEffect } = React;
 
 class NavigationManager {
@@ -341,3 +342,4 @@ document.addEventListener('DOMContentLoaded', () => {
     root.render(React.createElement(NavGroupManager));
 });
 
+})();

--- a/src/static/js/userMenu.js
+++ b/src/static/js/userMenu.js
@@ -1,87 +1,89 @@
-const { useState, useEffect, useRef } = React;
+(() => {
+  const { useState, useEffect, useRef } = React;
 
-function UserMenu() {
-  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-  const menuRef = useRef(null);
+  function UserMenu() {
+    const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+    const menuRef = useRef(null);
 
-  useEffect(() => {
-    function handleDocumentClick(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setIsUserMenuOpen(false);
-      }
-    }
-    document.addEventListener('click', handleDocumentClick);
-    return () => document.removeEventListener('click', handleDocumentClick);
-  }, []);
-
-  return React.createElement(
-    'div',
-    { ref: menuRef },
-    React.createElement(
-      'button',
-      {
-        className: 'user-btn',
-        onClick: (e) => {
-          e.stopPropagation();
-          setIsUserMenuOpen(!isUserMenuOpen);
+    useEffect(() => {
+      function handleDocumentClick(e) {
+        if (menuRef.current && !menuRef.current.contains(e.target)) {
+          setIsUserMenuOpen(false);
         }
-      },
-      React.createElement('i', { className: 'fas fa-user-circle' }),
-      React.createElement('span', { id: 'user-name' }, 'Usuário'),
-      React.createElement('i', { className: 'fas fa-chevron-down' })
-    ),
-    React.createElement(
-      'div',
-      { className: `user-dropdown${isUserMenuOpen ? ' show' : ''}` },
-      React.createElement(
-        'a',
-        {
-          href: '#',
-          id: 'user-profile',
-          onClick: (e) => {
-            e.preventDefault();
-            window.navigation && window.navigation.showUserProfile();
-            setIsUserMenuOpen(false);
-          }
-        },
-        React.createElement('i', { className: 'fas fa-user' }),
-        ' Perfil'
-      ),
-      React.createElement(
-        'a',
-        {
-          href: '#',
-          id: 'user-settings',
-          onClick: (e) => {
-            e.preventDefault();
-            window.navigation && window.navigation.showUserSettings();
-            setIsUserMenuOpen(false);
-          }
-        },
-        React.createElement('i', { className: 'fas fa-cog' }),
-        ' Configurações'
-      ),
-      React.createElement('hr', null),
-      React.createElement(
-        'a',
-        {
-          href: '#',
-          id: 'logout',
-          onClick: (e) => {
-            e.preventDefault();
-            window.navigation && window.navigation.handleLogout();
-            setIsUserMenuOpen(false);
-          }
-        },
-        React.createElement('i', { className: 'fas fa-sign-out-alt' }),
-        ' Sair'
-      )
-    )
-  );
-}
+      }
+      document.addEventListener('click', handleDocumentClick);
+      return () => document.removeEventListener('click', handleDocumentClick);
+    }, []);
 
-const rootElement = document.getElementById('user-menu-root');
-if (rootElement) {
-  const root = ReactDOM.createRoot(rootElement);
-  root.render(React.createElement(UserMenu));
-}
+    return React.createElement(
+      'div',
+      { ref: menuRef },
+      React.createElement(
+        'button',
+        {
+          className: 'user-btn',
+          onClick: (e) => {
+            e.stopPropagation();
+            setIsUserMenuOpen(!isUserMenuOpen);
+          }
+        },
+        React.createElement('i', { className: 'fas fa-user-circle' }),
+        React.createElement('span', { id: 'user-name' }, 'Usuário'),
+        React.createElement('i', { className: 'fas fa-chevron-down' })
+      ),
+      React.createElement(
+        'div',
+        { className: `user-dropdown${isUserMenuOpen ? ' show' : ''}` },
+        React.createElement(
+          'a',
+          {
+            href: '#',
+            id: 'user-profile',
+            onClick: (e) => {
+              e.preventDefault();
+              window.navigation && window.navigation.showUserProfile();
+              setIsUserMenuOpen(false);
+            }
+          },
+          React.createElement('i', { className: 'fas fa-user' }),
+          ' Perfil'
+        ),
+        React.createElement(
+          'a',
+          {
+            href: '#',
+            id: 'user-settings',
+            onClick: (e) => {
+              e.preventDefault();
+              window.navigation && window.navigation.showUserSettings();
+              setIsUserMenuOpen(false);
+            }
+          },
+          React.createElement('i', { className: 'fas fa-cog' }),
+          ' Configurações'
+        ),
+        React.createElement('hr', null),
+        React.createElement(
+          'a',
+          {
+            href: '#',
+            id: 'logout',
+            onClick: (e) => {
+              e.preventDefault();
+              window.navigation && window.navigation.handleLogout();
+              setIsUserMenuOpen(false);
+            }
+          },
+          React.createElement('i', { className: 'fas fa-sign-out-alt' }),
+          ' Sair'
+        )
+      )
+    );
+  }
+
+  const rootElement = document.getElementById('user-menu-root');
+  if (rootElement) {
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(React.createElement(UserMenu));
+  }
+})();


### PR DESCRIPTION
## Summary
- wrap user menu component in an IIFE to keep React hooks scoped and avoid global conflicts
- isolate navigation manager React hooks inside an IIFE and keep global access through `NavigationManager`

## Testing
- `pytest`
- `node --check src/static/js/userMenu.js`
- `node --check src/static/js/navigation.js`


------
https://chatgpt.com/codex/tasks/task_e_6893b85936a4832cacdba661ef50eefc