### PR TITLE
fix: improve frontend API URLs and test stubs

### DIFF
--- a/src/static/js/pages/itens.js
+++ b/src/static/js/pages/itens.js
@@ -1,6 +1,7 @@
 
 document.addEventListener("DOMContentLoaded", function () {
-    const apiUrl = "/api/itens";
+    // Usar a URL base configurada dinamicamente para evitar problemas de mixed content
+    const apiUrl = `${window.API_BASE_URL}/itens/`;
 
     const form = document.getElementById("item-form");
     const tabela = document.getElementById("tabela-itens");

--- a/src/static/js/test-data.js
+++ b/src/static/js/test-data.js
@@ -542,25 +542,37 @@ class TestData {
                     return { success: true };
                 }
             },
-            workOrders: {
-                getAll: async () => {
-                    await delay(600);
-                    return TestData.getWorkOrders();
+             workOrders: {
+                 getAll: async () => {
+                     await delay(600);
+                     return TestData.getWorkOrders();
+                 },
+                 create: async (data) => {
+                     await delay(400);
+                     console.log('Criando OS:', data);
+                     return { id: Date.now(), ...data };
+                 },
+                 update: async (id, data) => {
+                     await delay(400);
+                     console.log('Atualizando OS:', id, data);
+                     return { id, ...data };
+                 },
+                 delete: async (id) => {
+                     await delay(300);
+                     console.log('Excluindo OS:', id);
+                     return { success: true };
                 },
-                create: async (data) => {
-                    await delay(400);
-                    console.log('Criando OS:', data);
-                    return { id: Date.now(), ...data };
-                },
-                update: async (id, data) => {
-                    await delay(400);
-                    console.log('Atualizando OS:', id, data);
-                    return { id, ...data };
-                },
-                delete: async (id) => {
+                getMechanicAlerts: async () => {
                     await delay(300);
-                    console.log('Excluindo OS:', id);
-                    return { success: true };
+                    // Considera todas as OS não concluídas como alertas
+                    const alertas = TestData.getWorkOrders().filter(os => os.status !== 'concluida');
+                    return { total_alertas: alertas.length, alertas };
+                }
+            },
+            tires: {
+                getAlerts: async () => {
+                    await delay(300);
+                    return { total_alertas: 0, alertas: [] };
                 }
             },
             stock: {


### PR DESCRIPTION
## Summary
- use API_BASE_URL for items API requests to avoid mixed content
- add getMechanicAlerts and tire alert stubs to test API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c38ef14c832c9139d65178fe4506