### PR TITLE
Fix navigation mapping to load pages dynamically

### DIFF
--- a/src/static/js/navigation.js
+++ b/src/static/js/navigation.js
@@ -4,22 +4,24 @@ class NavigationManager {
     this.container = document.getElementById('main-content');
     this.menuToggle = document.getElementById('menu-toggle');
 
-    this.pages = {
-      'dashboard': window.DashboardPage,
-      'ordens-servico': window.WorkOrdersPage,
-      'preventivas': window.PreventivasPage,
-      'backlog': window.BacklogPage,
-      'equipamentos': window.EquipmentsPage,
-      'estoque': window.InventoryPage,
-      'pneus': window.TiresPage,
-      'mecanicos': window.MechanicsPage,
-      'usuarios': window.UsersPage,
-      'tipos-equipamento': window.EquipmentTypesPage,
-      'tipos-manutencao': window.MaintenanceTypesPage,
-      'grupos-item': window.ItemGroupsPage,
-      'movimentacoes': window.MovementsPage,
-      'analise-oleo': window.OilAnalysisPage,
-      'importacao': window.ImportPage
+    // Mapear nomes das páginas para seus construtores globais
+    // A resolução dos construtores é feita dinamicamente em `getPageClass`
+    this.pageMap = {
+      'dashboard': 'DashboardPage',
+      'ordens-servico': 'WorkOrdersPage',
+      'preventivas': 'PreventivasPage',
+      'backlog': 'BacklogPage',
+      'equipamentos': 'EquipmentsPage',
+      'estoque': 'InventoryPage',
+      'pneus': 'TiresPage',
+      'mecanicos': 'MechanicsPage',
+      'usuarios': 'UsersPage',
+      'tipos-equipamento': 'EquipmentTypesPage',
+      'tipos-manutencao': 'MaintenanceTypesPage',
+      'grupos-item': 'ItemGroupsPage',
+      'movimentacoes': 'MovementsPage',
+      'analise-oleo': 'OilAnalysisPage',
+      'importacao': 'ImportPage'
     };
 
     this.init();
@@ -71,6 +73,11 @@ class NavigationManager {
     });
   }
 
+  getPageClass(page) {
+    const className = this.pageMap[page];
+    return className ? window[className] : undefined;
+  }
+
   setActiveLink(link) {
     document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
     if (link) {
@@ -80,8 +87,7 @@ class NavigationManager {
 
   async navigateTo(page) {
     if (!this.container) return;
-
-    const PageClass = this.pages[page];
+    const PageClass = this.getPageClass(page);
     if (!PageClass) {
       console.warn(`Página desconhecida: ${page}`);
       this.container.innerHTML = '<p>Página não encontrada.</p>';


### PR DESCRIPTION
## Summary
- Resolve page constructors dynamically to ensure navigation works reliably
- Added helper for page lookup in navigation manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b5797774832cb4d2be10b6c3aaf6