### PR TITLE
Fix navigation manager initialization and script path

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -248,7 +248,7 @@
     <!-- Scripts -->
     <script src="/js/vendor/jquery-3.7.1.min.js"></script>
     <script src="/js/vendor/bootstrap.min.js"></script>
-    <script src="/static/js/vendor/ag-grid-enterprise.min.js"></script>
+    <script src="/js/vendor/ag-grid-enterprise.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/ag-charts-community/dist/ag-charts-community.min.js"></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -108,8 +108,8 @@ class CMSApp {
             }
 
             // Inicializar gerenciador de navegação após autenticação
-            if (!window.navigation) {
-                window.navigation = new NavigationManager();
+            if (!window.appNavigation) {
+                window.appNavigation = new NavigationManager();
             }
 
             // Carregar notificações
@@ -203,7 +203,7 @@ class CMSApp {
         // Callback de logout
         auth.onLogout(() => {
             console.log('Logout realizado');
-            window.navigation = null;
+            window.appNavigation = null;
             this.showLogin();
         });
     }
@@ -238,7 +238,7 @@ class CMSApp {
         return {
             initialized: this.initialized,
             currentUser: auth.getCurrentUser(),
-            currentPage: navigation.getCurrentPage()
+            currentPage: window.appNavigation?.getCurrentPage()
         };
     }
 }

--- a/src/static/js/pages/dashboard.js
+++ b/src/static/js/pages/dashboard.js
@@ -67,7 +67,7 @@ class DashboardPage {
                 </div>
                 <h3>Erro ao carregar dashboard</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo('dashboard')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo('dashboard')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>
@@ -375,7 +375,7 @@ class DashboardPage {
         
         const route = routes[index];
         if (route) {
-            navigation.navigateTo(route);
+            appNavigation.navigateTo(route);
         }
     }
 

--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -657,7 +657,7 @@ class EquipmentsPage {
                 </div>
                 <h3>Erro ao carregar equipamentos</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo('equipamentos')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo('equipamentos')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -71,7 +71,7 @@ class InventoryPage {
                 </div>
                 <h3>Erro ao carregar estoque</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo('estoque')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo('estoque')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>
@@ -387,7 +387,7 @@ class InventoryPage {
         // Botão de movimentações
         const movementBtn = container.querySelector('#movement-history');
         if (movementBtn) {
-            movementBtn.addEventListener('click', () => navigation.navigateTo('movimentacoes'));
+            movementBtn.addEventListener('click', () => appNavigation.navigateTo('movimentacoes'));
         }
 
         // Botão de nova peça

--- a/src/static/js/pages/mecanicos.js
+++ b/src/static/js/pages/mecanicos.js
@@ -59,7 +59,7 @@ class MechanicsPage {
                 </div>
                 <h3>Erro ao carregar mecânicos</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo('mecanicos')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo('mecanicos')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>
@@ -444,7 +444,7 @@ class MechanicsPage {
 
     viewWorkOrders(id) {
         // Navegar para ordens de serviço filtradas por mecânico
-        navigation.navigateTo('ordens-servico', { mechanic_id: id });
+        appNavigation.navigateTo('ordens-servico', { mechanic_id: id });
     }
 
     editMechanic(id) {

--- a/src/static/js/pages/ordens-servico.js
+++ b/src/static/js/pages/ordens-servico.js
@@ -790,7 +790,7 @@ class WorkOrdersPage {
                 </div>
                 <h3>Erro ao carregar ordens de serviço</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo(\'ordens-servico\')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo(\'ordens-servico\')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>

--- a/src/static/js/pages/pneus.js
+++ b/src/static/js/pages/pneus.js
@@ -679,7 +679,7 @@ class TiresPage {
                 </div>
                 <h3>Erro ao carregar pneus</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo(\'pneus\')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo(\'pneus\')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>

--- a/src/static/js/pages/usuarios.js
+++ b/src/static/js/pages/usuarios.js
@@ -638,7 +638,7 @@ class UsersPage {
                 </div>
                 <h3>Erro ao carregar usuários</h3>
                 <p>${message}</p>
-                <button class="btn btn-primary" onclick="navigation.navigateTo(\'usuarios\')">
+                <button class="btn btn-primary" onclick="appNavigation.navigateTo(\'usuarios\')">
                     <i class="fas fa-refresh"></i>
                     Tentar novamente
                 </button>


### PR DESCRIPTION
## Summary
- Avoid conflict with browser Navigation API by using `appNavigation` for custom navigation manager
- Adjust references in page scripts to use `appNavigation`
- Correct ag-grid enterprise script path so dependency loads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894b7dcd63c832c9abf8aa4a5024bdd