### PR TITLE
refactor: use centralized API service

### DIFF
--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -47,3 +47,73 @@ class ApiClient {
 // Tornar disponíveis globalmente
 window.api = new ApiClient();
 window.API_BASE_URL = API_BASE_URL;
+
+// Helper para operações CRUD básicas
+const createCRUD = (base) => ({
+    getAll: () => window.api.request(base),
+    get: (id) => window.api.request(`${base}/${id}`),
+    create: (data) => window.api.request(base, {
+        method: 'POST',
+        body: JSON.stringify(data)
+    }),
+    update: (id, data) => window.api.request(`${base}/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data)
+    }),
+    delete: (id) => window.api.request(`${base}/${id}`, {
+        method: 'DELETE'
+    })
+});
+
+// Módulos da API
+const API = {
+    auth: {
+        login: (credentials) => window.api.request('/auth/login', {
+            method: 'POST',
+            body: JSON.stringify(credentials)
+        }),
+        logout: () => window.api.request('/auth/logout', { method: 'POST' }),
+        me: () => window.api.request('/auth/me')
+    },
+    equipments: createCRUD('/equipamentos'),
+    equipmentTypes: {
+        getAll: () => window.api.request('/tipos-equipamento')
+    },
+    workOrders: {
+        ...createCRUD('/ordens-servico'),
+        getMechanicAlerts: () => window.api.request('/ordens-servico/alertas')
+    },
+    mechanics: createCRUD('/mecanicos'),
+    maintenanceTypes: createCRUD('/tipos-manutencao'),
+    tires: {
+        ...createCRUD('/pneus'),
+        getAlerts: () => window.api.request('/pneus/alertas')
+    },
+    inventory: {
+        ...createCRUD('/estoque'),
+        movement: (id, data) => window.api.request(`/estoque/${id}/movimentacoes`, {
+            method: 'POST',
+            body: JSON.stringify(data)
+        })
+    },
+    itemGroups: createCRUD('/grupos-item'),
+    users: {
+        ...createCRUD('/usuarios'),
+        resetPassword: (id) => window.api.request(`/usuarios/${id}/reset-password`, {
+            method: 'POST'
+        })
+    },
+    dashboard: {
+        getStats: () => window.api.request('/dashboard/stats')
+    },
+    backlog: createCRUD('/backlog'),
+    preventivePlans: createCRUD('/preventivas'),
+    movements: createCRUD('/movimentacoes'),
+    oilAnalysis: createCRUD('/analise-oleo'),
+    items: createCRUD('/itens')
+};
+
+// Alias em português quando necessário
+API.equipamentos = API.equipments;
+
+window.API = API;

--- a/src/static/js/pages/equipamentos.js
+++ b/src/static/js/pages/equipamentos.js
@@ -10,18 +10,8 @@ const SYNC_EQUIPMENTS_GRID_DATA = async () => {
     equipmentsGridApi.showLoadingOverlay();
 
     try {
-        const response = await fetch('/api/equipamentos', {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('token')}`
-            }
-        });
-        
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        
-        const data = await response.json();
-        equipmentsData = data.equipamentos || [];
+        const data = await API.equipments.getAll();
+        equipmentsData = data.equipamentos || data.data || data || [];
         
         equipmentsGridApi.setGridOption("rowData", equipmentsData);
         updateEquipmentsStats();
@@ -158,20 +148,7 @@ const ADD_EQUIPAMENTO = async () => {
         }
 
         try {
-            const response = await fetch('/api/equipamentos', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`
-                },
-                body: JSON.stringify(formData)
-            });
-
-            if (!response.ok) {
-                const error = await response.json();
-                throw new Error(error.error || 'Erro ao criar equipamento');
-            }
-
+            await API.equipments.create(formData);
             await SYNC_EQUIPMENTS_GRID_DATA();
             $(modal).modal('hide');
             Utils.showToast('Equipamento criado com sucesso!', 'success');
@@ -268,20 +245,7 @@ const EDIT_EQUIPAMENTO = async (params) => {
         const formData = EQUIPMENTS_FORMDATA(modalBody);
 
         try {
-            const response = await fetch(`/api/equipamentos/${rowData.id}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`
-                },
-                body: JSON.stringify(formData)
-            });
-
-            if (!response.ok) {
-                const error = await response.json();
-                throw new Error(error.error || 'Erro ao atualizar equipamento');
-            }
-
+            await API.equipments.update(rowData.id, formData);
             await SYNC_EQUIPMENTS_GRID_DATA();
             $(modal).modal('hide');
             Utils.showToast('Equipamento atualizado com sucesso!', 'success');
@@ -305,18 +269,7 @@ const DELETE_EQUIPAMENTO = async (params) => {
     if (!confirmed) return;
 
     try {
-        const response = await fetch(`/api/equipamentos/${rowData.id}`, {
-            method: 'DELETE',
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('token')}`
-            }
-        });
-
-        if (!response.ok) {
-            const error = await response.json();
-            throw new Error(error.error || 'Erro ao excluir equipamento');
-        }
-
+        await API.equipments.delete(rowData.id);
         params.api.applyTransaction({ remove: [rowData] });
         params.api.refreshCells({ force: true });
         updateEquipmentsStats();
@@ -329,16 +282,8 @@ const DELETE_EQUIPAMENTO = async (params) => {
 
 const loadEquipmentTypes = async () => {
     try {
-        const response = await fetch('/api/tipos-equipamento', {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('token')}`
-            }
-        });
-        
-        if (response.ok) {
-            const data = await response.json();
-            equipmentTypes = data.tipos_equipamento || [];
-        }
+        const data = await API.equipmentTypes.getAll();
+        equipmentTypes = data.tipos_equipamento || data.data || data || [];
     } catch (error) {
         console.error('Erro ao carregar tipos de equipamento:', error);
         equipmentTypes = [];

--- a/src/static/js/pages/estoque.js
+++ b/src/static/js/pages/estoque.js
@@ -757,8 +757,8 @@ class InventoryItemModal {
 
     async loadItems() {
         try {
-            const response = await fetch('/api/itens');
-            const items = await response.json();
+            const resp = await API.items.getAll();
+            const items = resp.itens || resp.data || resp || [];
             const select = document.getElementById('item_id');
             if (!select) return;
 

--- a/src/static/js/pages/itens.js
+++ b/src/static/js/pages/itens.js
@@ -1,7 +1,7 @@
 
 document.addEventListener("DOMContentLoaded", function () {
     // Usar a URL base configurada dinamicamente para evitar problemas de mixed content
-    const apiUrl = `${window.API_BASE_URL}/itens/`;
+    const apiUrl = `${window.API_BASE_URL}/itens/`; // mantido para compatibilidade, não utilizado diretamente
 
     const form = document.getElementById("item-form");
     const tabela = document.getElementById("tabela-itens");
@@ -25,9 +25,9 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     function carregarItens() {
-        fetch(apiUrl)
-            .then(res => res.json())
-            .then(data => {
+        API.items.getAll()
+            .then(response => {
+                const data = response.itens || response.data || response || [];
                 tabela.innerHTML = "";
                 data.forEach(item => {
                     const row = document.createElement("tr");
@@ -59,16 +59,10 @@ document.addEventListener("DOMContentLoaded", function () {
                 estoque_baixo: form.estoque_baixo.checked
             };
 
-            fetch(apiUrl, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(dados)
-            })
-                .then(res => {
-                    if (res.ok) {
-                        form.reset();
-                        carregarItens();
-                    }
+            API.items.create(dados)
+                .then(() => {
+                    form.reset();
+                    carregarItens();
                 });
         });
     }

--- a/src/static/js/test-data.js
+++ b/src/static/js/test-data.js
@@ -520,6 +520,35 @@ class TestData {
         ];
     }
 
+    static getTires() {
+        return [
+            {
+                id: 1,
+                numero_serie: 'PN001',
+                numero_fogo: 'F001',
+                marca: 'Goodyear',
+                modelo: 'G1',
+                medida: '385/65R22.5',
+                status: 'estoque',
+                sulco_inicial: 15,
+                sulco_atual: 15,
+                item_id: 1
+            },
+            {
+                id: 2,
+                numero_serie: 'PN002',
+                numero_fogo: 'F002',
+                marca: 'Michelin',
+                modelo: 'X1',
+                medida: '295/80R22.5',
+                status: 'em_uso',
+                sulco_inicial: 18,
+                sulco_atual: 17,
+                item_id: 1
+            }
+        ];
+    }
+
     static getOilAnalysis() {
         return [
             { id: 1, numero_amostra: 'A2024-001', equipamento_id: 1, equipamento_nome: 'Escavadeira CAT 320D', data_coleta: '2024-01-15', status: 'Em análise', resultado: null },
@@ -639,9 +668,49 @@ class TestData {
                 }
             },
             tires: {
+                getAll: async () => {
+                    await delay(300);
+                    return TestData.getTires();
+                },
+                create: async (data) => {
+                    await delay(300);
+                    console.log('Criando pneu:', data);
+                    return { id: Date.now(), ...data };
+                },
+                update: async (id, data) => {
+                    await delay(300);
+                    console.log('Atualizando pneu:', id, data);
+                    return { id, ...data };
+                },
+                delete: async (id) => {
+                    await delay(200);
+                    console.log('Excluindo pneu:', id);
+                    return { success: true };
+                },
                 getAlerts: async () => {
                     await delay(300);
                     return { total_alertas: 0, alertas: [] };
+                }
+            },
+            items: {
+                getAll: async () => {
+                    await delay(300);
+                    return TestData.getStockItems();
+                },
+                create: async (data) => {
+                    await delay(300);
+                    console.log('Criando item:', data);
+                    return { id: Date.now(), ...data };
+                },
+                update: async (id, data) => {
+                    await delay(300);
+                    console.log('Atualizando item:', id, data);
+                    return { id, ...data };
+                },
+                delete: async (id) => {
+                    await delay(200);
+                    console.log('Excluindo item:', id);
+                    return { success: true };
                 }
             },
             stock: {
@@ -962,6 +1031,7 @@ class TestData {
         console.log('- Itens de Backlog:', this.getBacklogItems().length);
         console.log('- Planos de Preventiva:', this.getPreventivePlans().length);
         console.log('- Movimentações:', this.getMovements().length);
+        console.log('- Pneus:', this.getTires().length);
         console.log('- Tipos de Equipamento:', this.getEquipmentTypes().length);
         console.log('- Análises de Óleo:', this.getOilAnalysis().length);
     }


### PR DESCRIPTION
## Summary
- centralize HTTP requests in API service and add CRUD modules
- update pages to use API modules instead of direct fetch calls
- extend test data with tires and items modules

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c5a3397c832cbaf73e03ae495b5c