### PR TITLE
Use python3 for app startup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python src/main.py
+web: python3 src/main.py
 

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python src/main.py",
+    "startCommand": "python3 src/main.py",
     "healthcheckPath": "/api/health",
     "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary
- ensure the service uses `python3` to start the Flask app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894d0a9b100832c87b61a373a0d576c