### PR TITLE
Use generic python interpreter for db tools

### DIFF
--- a/INSTALACAO.md
+++ b/INSTALACAO.md
@@ -15,7 +15,7 @@
 cd cmms_sistema
 
 # Crie um ambiente virtual
-python3.11 -m venv venv
+python -m venv venv
 
 # Ative o ambiente virtual
 # Linux/Mac:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python3 src/main.py
+web: python src/main.py
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ src/
 ### Opção 1: Servidor HTTP Simples (Recomendado para testes)
 ```bash
 cd src/static
-python3 -m http.server 8000
+python -m http.server 8000
 ```
 Acesse: http://localhost:8000
 
 ### Opção 2: Servidor Flask (Para funcionalidades completas)
 ```bash
 cd src
-python3 app.py
+python app.py
 ```
 Acesse: http://localhost:5000
 

--- a/create_db.py
+++ b/create_db.py
@@ -1,7 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import sys
+
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python 3.8+ is required to run this script.")
 
 # Adicionar o diretório raiz ao path
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/init_db.py
+++ b/init_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Script de inicialização do banco de dados CMMS.
 Cria tabelas e dados iniciais necessários.
@@ -6,6 +6,9 @@ Cria tabelas e dados iniciais necessários.
 
 import os
 import sys
+
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python 3.8+ is required to run this script.")
 
 # Adicionar o diretório raiz ao path
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python3 src/main.py",
+    "startCommand": "python src/main.py",
     "healthcheckPath": "/api/health",
     "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",

--- a/scripts/import_example_itens.py
+++ b/scripts/import_example_itens.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Importar itens de Example/itens.csv para a tabela pecas."""
 import os
 import sys
 import pandas as pd
 from flask import Flask
+
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python 3.8+ is required to run this script.")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -13,7 +16,9 @@ from src.models.grupo_item import GrupoItem
 from src.models.estoque_local import EstoqueLocal
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-DATABASE_URL = os.environ.get('DATABASE_URL', f"sqlite:///{os.path.join(BASE_DIR, 'instance', 'cmms_local.db')}")
+INSTANCE_DIR = os.path.join(BASE_DIR, 'instance')
+os.makedirs(INSTANCE_DIR, exist_ok=True)
+DATABASE_URL = os.environ.get('DATABASE_URL', f"sqlite:///{os.path.join(INSTANCE_DIR, 'cmms_local.db')}")
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL


### PR DESCRIPTION
## Summary
- Use environment-agnostic `python` shebang and add Python 3.8+ check in database scripts
- Ensure import script creates database path and supports generic interpreter
- Update deployment configs and docs to invoke `python` instead of `python3`

## Testing
- `python create_db.py`


------
https://chatgpt.com/codex/tasks/task_e_689612509984832ca220899477d5408a