### PR TITLE
Enforce JWT secret configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DATABASE_URL=postgresql://username:password@hostname:port/database_name
 
 # Configurações da Aplicação
 SECRET_KEY=your-secret-key-here
+JWT_SECRET_KEY=your-jwt-secret-key-here
 FLASK_ENV=production
 FLASK_DEBUG=False
 

--- a/INSTALACAO.md
+++ b/INSTALACAO.md
@@ -43,9 +43,12 @@ python init_db.py
 
 ### 4. Execução da Aplicação
 
+A aplicação exige a variável de ambiente `JWT_SECRET_KEY` para geração de tokens JWT.
+
 ```bash
-# Configure a variável de ambiente (opcional)
-export DATABASE_URL='sqlite:///cmms.db'
+# Configure as variáveis de ambiente
+export JWT_SECRET_KEY='sua_chave_secreta'  # Obrigatório
+export DATABASE_URL='sqlite:///cmms.db'    # Opcional
 
 # Execute a aplicação
 python src/main.py

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -2,13 +2,11 @@ from flask import Blueprint, request, jsonify
 from werkzeug.security import check_password_hash
 from src.db import db
 from src.models.usuario import Usuario
-from src.utils.auth import token_required, get_user_permissions
+from src.utils.auth import token_required, get_user_permissions, SECRET_KEY
 import jwt
 from datetime import datetime, timedelta
-import os
 
 auth_bp = Blueprint('auth', __name__)
-SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'supersecretkey')
 
 @auth_bp.route('/auth/login', methods=['POST'])
 def login():

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -8,7 +8,9 @@ from src.models.usuario import Usuario
 import jwt
 import os
 
-SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'supersecretkey')
+SECRET_KEY = os.environ.get('JWT_SECRET_KEY')
+if not SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY environment variable is not set")
 
 def token_required(f):
     """Decorator para verificar se o token JWT é válido"""


### PR DESCRIPTION
## Summary
- Raise startup error when `JWT_SECRET_KEY` is missing and share key import across auth modules
- Document `JWT_SECRET_KEY` requirement in installation guide and sample environment file

## Testing
- `JWT_SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_689628a91010832cae85ea2c4af4761b