### PR TITLE
Log exceptions and hide internal errors

### DIFF
--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -4,6 +4,7 @@ from src.db import db
 from src.models.usuario import Usuario
 from src.utils.auth import token_required, get_user_permissions, SECRET_KEY
 import jwt
+import logging
 from datetime import datetime, timedelta
 
 auth_bp = Blueprint('auth', __name__)
@@ -47,8 +48,9 @@ def login():
             'message': 'Login realizado com sucesso'
         }), 200
 
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao realizar login")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @auth_bp.route('/auth/validate', methods=['GET'])
 @token_required
@@ -95,6 +97,7 @@ def change_password(current_user):
 
         return jsonify({'message': 'Senha alterada com sucesso'}), 200
 
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao alterar senha")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 

--- a/src/routes/equipamentos.py
+++ b/src/routes/equipamentos.py
@@ -4,6 +4,7 @@ from src.models.equipamento import Equipamento
 from src.models.tipo_equipamento import TipoEquipamento
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime
+import logging
 
 equipamentos_bp = Blueprint('equipamentos', __name__)
 
@@ -45,9 +46,9 @@ def get_equipamentos(current_user):
             'total': len(result)
         }), 200
         
-    except Exception as e:
-        print(f"Erro ao carregar equipamentos: {str(e)}")
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao carregar equipamentos")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos/<int:equipamento_id>', methods=['GET'])
 @token_required
@@ -55,8 +56,9 @@ def get_equipamento(current_user, equipamento_id):
     try:
         equipamento = Equipamento.query.get_or_404(equipamento_id)
         return jsonify(equipamento.to_dict()), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao carregar equipamento")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos', methods=['POST'])
 @token_required
@@ -100,9 +102,10 @@ def create_equipamento(current_user):
             "equipamento": equipamento.to_dict()
         }), 201
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({"error": str(e)}), 500
+        logging.exception("Erro ao criar equipamento")
+        return jsonify({"error": 'Erro interno do servidor'}), 500
 @equipamentos_bp.route("/equipamentos/<int:equipamento_id>", methods=["PUT"])
 @token_required
 @supervisor_or_admin_required
@@ -139,9 +142,10 @@ def update_equipamento(current_user, equipamento_id):
             "equipamento": equipamento.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({"error": str(e)}), 500
+        logging.exception("Erro ao atualizar equipamento")
+        return jsonify({"error": 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos/<int:equipamento_id>', methods=['DELETE'])
 @token_required
@@ -159,6 +163,7 @@ def delete_equipamento(current_user, equipamento_id):
         
         return jsonify({'message': 'Equipamento excluído com sucesso'}), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Erro ao excluir equipamento")
+        return jsonify({'error': 'Erro interno do servidor'}), 500

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -3,6 +3,7 @@ from src.db import db
 from src.models.usuario import Usuario
 from src.utils.auth import token_required, admin_required
 from datetime import datetime
+import logging
 
 usuarios_bp = Blueprint('usuarios', __name__)
 
@@ -35,9 +36,9 @@ def get_usuarios(current_user):
             'total': len(usuarios)
         }), 200
         
-    except Exception as e:
-        print(f"Erro ao carregar usuários: {str(e)}")
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao carregar usuários")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['GET'])
 @token_required
@@ -46,8 +47,9 @@ def get_usuario(current_user, usuario_id):
     try:
         usuario = Usuario.query.get_or_404(usuario_id)
         return jsonify(usuario.to_dict()), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao obter usuário")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios', methods=['POST'])
 @token_required
@@ -94,9 +96,10 @@ def create_usuario(current_user):
             'usuario': usuario.to_dict()
         }), 201
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Erro ao criar usuário")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['PUT'])
 @token_required
@@ -139,9 +142,10 @@ def update_usuario(current_user, usuario_id):
             'usuario': usuario.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Erro ao atualizar usuário")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['DELETE'])
 @token_required
@@ -158,17 +162,19 @@ def delete_usuario(current_user, usuario_id):
         
         return jsonify({'message': 'Usuário excluído com sucesso'}), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Erro ao excluir usuário")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/perfil', methods=['GET'])
 @token_required
 def get_perfil(current_user):
     try:
         return jsonify(current_user.to_dict()), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao obter perfil")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/perfil', methods=['PUT'])
 @token_required
@@ -200,9 +206,10 @@ def update_perfil(current_user):
             'usuario': current_user.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Erro ao atualizar perfil")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/niveis-acesso', methods=['GET'])
 @token_required
@@ -219,6 +226,7 @@ def get_niveis_acesso(current_user):
         
         return jsonify({'niveis_acesso': niveis}), 200
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logging.exception("Erro ao listar níveis de acesso")
+        return jsonify({'error': 'Erro interno do servidor'}), 500
 


### PR DESCRIPTION
## Summary
- log exceptions in auth, equipment, and user routes
- return generic server error messages instead of exception details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689644714498832c84cc4e73b76f9e8b