### PR TITLE
Add database rollback handling to auth and item routes

### DIFF
--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -50,6 +50,7 @@ def login():
 
     except Exception:
         logging.exception("Erro ao realizar login")
+        db.session.rollback()
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @auth_bp.route('/auth/validate', methods=['GET'])
@@ -99,5 +100,6 @@ def change_password(current_user):
 
     except Exception:
         logging.exception("Erro ao alterar senha")
+        db.session.rollback()
         return jsonify({'error': 'Erro interno do servidor'}), 500
 

--- a/src/routes/item_routes.py
+++ b/src/routes/item_routes.py
@@ -30,78 +30,93 @@ def listar_itens():
 
 @item_bp.route('/', methods=['POST'])
 def criar_item():
-    data = request.get_json() or {}
+    try:
+        data = request.get_json() or {}
 
-    numero_item = data.get('numero_item')
-    descricao_item = data.get('descricao_item')
-    if not numero_item or not descricao_item:
-        return (
-            jsonify(
-                {'message': 'Campos numero_item e descricao_item são obrigatórios'}
-            ),
-            400,
+        numero_item = data.get('numero_item')
+        descricao_item = data.get('descricao_item')
+        if not numero_item or not descricao_item:
+            return (
+                jsonify(
+                    {'message': 'Campos numero_item e descricao_item são obrigatórios'}
+                ),
+                400,
+            )
+
+        if db.session.query(Item).filter_by(numero_item=numero_item).first():
+            return jsonify({'message': 'Número do item já existe'}), 400
+
+        item = Item(
+            numero_item=numero_item,
+            descricao_item=descricao_item,
+            grupo_itens=data.get('grupo_itens'),
+            unidade_medida=data.get('unidade_medida'),
+            ultimo_preco_avaliacao=data.get('ultimo_preco_avaliacao'),
+            ultimo_preco_compra=data.get('ultimo_preco_compra'),
+            estoque_baixo=data.get('estoque_baixo', False),
         )
 
-    if db.session.query(Item).filter_by(numero_item=numero_item).first():
-        return jsonify({'message': 'Número do item já existe'}), 400
+        db.session.add(item)
+        db.session.commit()
+        return jsonify({'message': 'Item criado com sucesso.'}), 201
 
-    item = Item(
-        numero_item=numero_item,
-        descricao_item=descricao_item,
-        grupo_itens=data.get('grupo_itens'),
-        unidade_medida=data.get('unidade_medida'),
-        ultimo_preco_avaliacao=data.get('ultimo_preco_avaliacao'),
-        ultimo_preco_compra=data.get('ultimo_preco_compra'),
-        estoque_baixo=data.get('estoque_baixo', False),
-    )
-
-    db.session.add(item)
-    db.session.commit()
-    return jsonify({'message': 'Item criado com sucesso.'}), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
 
 
 @item_bp.route('/<int:item_id>', methods=['PUT'])
 def atualizar_item(item_id):
-    item = db.session.query(Item).get(item_id)
-    if not item:
-        return jsonify({'message': 'Item não encontrado'}), 404
+    try:
+        item = db.session.query(Item).get(item_id)
+        if not item:
+            return jsonify({'message': 'Item não encontrado'}), 404
 
-    data = request.get_json() or {}
+        data = request.get_json() or {}
 
-    if 'numero_item' in data:
-        numero_item = data['numero_item']
-        if (
-            db.session.query(Item)
-            .filter(Item.numero_item == numero_item, Item.id != item_id)
-            .first()
-        ):
-            return jsonify({'message': 'Número do item já existe'}), 400
-        item.numero_item = numero_item
+        if 'numero_item' in data:
+            numero_item = data['numero_item']
+            if (
+                db.session.query(Item)
+                .filter(Item.numero_item == numero_item, Item.id != item_id)
+                .first()
+            ):
+                return jsonify({'message': 'Número do item já existe'}), 400
+            item.numero_item = numero_item
 
-    if 'descricao_item' in data:
-        item.descricao_item = data['descricao_item']
-    if 'grupo_itens' in data:
-        item.grupo_itens = data['grupo_itens']
-    if 'unidade_medida' in data:
-        item.unidade_medida = data['unidade_medida']
-    if 'ultimo_preco_avaliacao' in data:
-        item.ultimo_preco_avaliacao = data['ultimo_preco_avaliacao']
-    if 'ultimo_preco_compra' in data:
-        item.ultimo_preco_compra = data['ultimo_preco_compra']
-    if 'estoque_baixo' in data:
-        item.estoque_baixo = data['estoque_baixo']
+        if 'descricao_item' in data:
+            item.descricao_item = data['descricao_item']
+        if 'grupo_itens' in data:
+            item.grupo_itens = data['grupo_itens']
+        if 'unidade_medida' in data:
+            item.unidade_medida = data['unidade_medida']
+        if 'ultimo_preco_avaliacao' in data:
+            item.ultimo_preco_avaliacao = data['ultimo_preco_avaliacao']
+        if 'ultimo_preco_compra' in data:
+            item.ultimo_preco_compra = data['ultimo_preco_compra']
+        if 'estoque_baixo' in data:
+            item.estoque_baixo = data['estoque_baixo']
 
-    db.session.commit()
-    return jsonify({'message': 'Item atualizado com sucesso'})
+        db.session.commit()
+        return jsonify({'message': 'Item atualizado com sucesso'})
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
 
 
 @item_bp.route('/<int:item_id>', methods=['DELETE'])
 def deletar_item(item_id):
-    item = db.session.query(Item).get(item_id)
-    if not item:
-        return jsonify({'message': 'Item não encontrado'}), 404
+    try:
+        item = db.session.query(Item).get(item_id)
+        if not item:
+            return jsonify({'message': 'Item não encontrado'}), 404
 
-    db.session.delete(item)
-    db.session.commit()
-    return jsonify({'message': 'Item deletado com sucesso'})
+        db.session.delete(item)
+        db.session.commit()
+        return jsonify({'message': 'Item deletado com sucesso'})
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
 


### PR DESCRIPTION
## Summary
- rollback database session if login or password change fails
- add error handling with rollback for item CRUD routes
- audit routes for consistent rollback usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689646f30b04832ca41465e7d34e9d16