### PR TITLE
Replace prints with logging in routes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -155,7 +155,7 @@ def health_check():
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
-    print(f"🌐 Servidor CMMS rodando na porta {port}")
+    logging.info("🌐 Servidor CMMS rodando na porta %s", port)
 
     # Verificar esquema e popular dados de exemplo
     with app.app_context():

--- a/src/routes/equipamentos.py
+++ b/src/routes/equipamentos.py
@@ -6,6 +6,9 @@ from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime
 import logging
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
 equipamentos_bp = Blueprint('equipamentos', __name__)
 
 @equipamentos_bp.route('/equipamentos', methods=['GET'])
@@ -47,7 +50,7 @@ def get_equipamentos(current_user):
         }), 200
         
     except Exception:
-        logging.exception("Erro ao carregar equipamentos")
+        logger.exception("Erro ao carregar equipamentos")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos/<int:equipamento_id>', methods=['GET'])
@@ -57,7 +60,7 @@ def get_equipamento(current_user, equipamento_id):
         equipamento = Equipamento.query.get_or_404(equipamento_id)
         return jsonify(equipamento.to_dict()), 200
     except Exception:
-        logging.exception("Erro ao carregar equipamento")
+        logger.exception("Erro ao carregar equipamento")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos', methods=['POST'])
@@ -104,7 +107,7 @@ def create_equipamento(current_user):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao criar equipamento")
+        logger.exception("Erro ao criar equipamento")
         return jsonify({"error": 'Erro interno do servidor'}), 500
 @equipamentos_bp.route("/equipamentos/<int:equipamento_id>", methods=["PUT"])
 @token_required
@@ -144,7 +147,7 @@ def update_equipamento(current_user, equipamento_id):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao atualizar equipamento")
+        logger.exception("Erro ao atualizar equipamento")
         return jsonify({"error": 'Erro interno do servidor'}), 500
 
 @equipamentos_bp.route('/equipamentos/<int:equipamento_id>', methods=['DELETE'])
@@ -165,5 +168,5 @@ def delete_equipamento(current_user, equipamento_id):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao excluir equipamento")
+        logger.exception("Erro ao excluir equipamento")
         return jsonify({'error': 'Erro interno do servidor'}), 500

--- a/src/routes/ordens_servico.py
+++ b/src/routes/ordens_servico.py
@@ -9,6 +9,10 @@ from src.models.os_peca import OS_Peca
 from src.models.movimentacao_estoque import MovimentacaoEstoque
 from src.utils.auth import token_required, supervisor_or_admin_required, pcm_or_above_required, mecanico_or_above_required
 from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 ordens_servico_bp = Blueprint('ordens_servico', __name__)
 
@@ -94,7 +98,7 @@ def get_ordens_servico(current_user):
         }), 200
         
     except Exception as e:
-        print(f"Erro ao carregar ordens de serviço: {str(e)}")
+        logger.exception("Erro ao carregar ordens de serviço")
         return jsonify({'error': str(e)}), 500
 
 @ordens_servico_bp.route('/ordens-servico/<int:os_id>', methods=['GET'])

--- a/src/routes/pneus.py
+++ b/src/routes/pneus.py
@@ -5,6 +5,10 @@ from src.models.equipamento import Equipamento
 from src.models.item import Item
 from src.utils.auth import token_required, supervisor_or_admin_required
 from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 pneus_bp = Blueprint('pneus', __name__)
 
@@ -59,7 +63,7 @@ def get_pneus(current_user):
         }), 200
         
     except Exception as e:
-        print(f"Erro ao carregar pneus: {str(e)}")
+        logger.exception("Erro ao carregar pneus")
         return jsonify({'error': str(e)}), 500
 
 @pneus_bp.route('/pneus/<int:pneu_id>', methods=['GET'])

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -5,6 +5,9 @@ from src.utils.auth import token_required, admin_required
 from datetime import datetime
 import logging
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
 usuarios_bp = Blueprint('usuarios', __name__)
 
 @usuarios_bp.route('/usuarios', methods=['GET'])
@@ -37,7 +40,7 @@ def get_usuarios(current_user):
         }), 200
         
     except Exception:
-        logging.exception("Erro ao carregar usuários")
+        logger.exception("Erro ao carregar usuários")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['GET'])
@@ -48,7 +51,7 @@ def get_usuario(current_user, usuario_id):
         usuario = Usuario.query.get_or_404(usuario_id)
         return jsonify(usuario.to_dict()), 200
     except Exception:
-        logging.exception("Erro ao obter usuário")
+        logger.exception("Erro ao obter usuário")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios', methods=['POST'])
@@ -98,7 +101,7 @@ def create_usuario(current_user):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao criar usuário")
+        logger.exception("Erro ao criar usuário")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['PUT'])
@@ -144,7 +147,7 @@ def update_usuario(current_user, usuario_id):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao atualizar usuário")
+        logger.exception("Erro ao atualizar usuário")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/<int:usuario_id>', methods=['DELETE'])
@@ -164,7 +167,7 @@ def delete_usuario(current_user, usuario_id):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao excluir usuário")
+        logger.exception("Erro ao excluir usuário")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/perfil', methods=['GET'])
@@ -173,7 +176,7 @@ def get_perfil(current_user):
     try:
         return jsonify(current_user.to_dict()), 200
     except Exception:
-        logging.exception("Erro ao obter perfil")
+        logger.exception("Erro ao obter perfil")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/perfil', methods=['PUT'])
@@ -208,7 +211,7 @@ def update_perfil(current_user):
         
     except Exception:
         db.session.rollback()
-        logging.exception("Erro ao atualizar perfil")
+        logger.exception("Erro ao atualizar perfil")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 
 @usuarios_bp.route('/usuarios/niveis-acesso', methods=['GET'])
@@ -227,6 +230,6 @@ def get_niveis_acesso(current_user):
         return jsonify({'niveis_acesso': niveis}), 200
         
     except Exception:
-        logging.exception("Erro ao listar níveis de acesso")
+        logger.exception("Erro ao listar níveis de acesso")
         return jsonify({'error': 'Erro interno do servidor'}), 500
 


### PR DESCRIPTION
## Summary
- add module-level logging configuration for routes
- use logging instead of print statements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689650b17b58832c81d871b173018499