### PR TITLE
Restrict CORS origins via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,9 @@ FLASK_ENV=production
 FLASK_DEBUG=False
 
 # Configurações de CORS (opcional)
-CORS_ORIGINS=*
+# Defina FRONTEND_URL com as origens permitidas separadas por vírgula
+# Exemplo: FRONTEND_URL=https://app.exemplo.com,https://admin.exemplo.com
+FRONTEND_URL=
 
 # Configurações de Upload (opcional)
 MAX_CONTENT_LENGTH=16777216

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ alembic stamp head
   Depois disso, utilize `alembic upgrade head` ou rode novamente
   `python create_db.py` para aplicar novas migrações.
 
+## Configuração de CORS
+
+Por padrão a API não permite requisições de outras origens.
+Defina a variável de ambiente `FRONTEND_URL` com uma lista separada
+por vírgulas para liberar o acesso a origens específicas:
+
+```bash
+export FRONTEND_URL="https://app.exemplo.com,https://admin.exemplo.com"
+```
+
+Se `FRONTEND_URL` não for definida, nenhuma origem externa será aceita.
+
 ## Credenciais de Teste
 
 - **E-mail:** admin@mineracao.com

--- a/src/main.py
+++ b/src/main.py
@@ -40,9 +40,12 @@ app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'sta
 SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-key')
 app.config['SECRET_KEY'] = SECRET_KEY
 
-# Configurar CORS para permitir credenciais de qualquer origem
-FRONTEND_URL = os.environ.get('FRONTEND_URL', '')
-CORS(app, supports_credentials=True, origins=[FRONTEND_URL] if FRONTEND_URL else "*")
+# Configurar CORS com origens permitidas definidas via variável de ambiente
+# Use uma lista separada por vírgulas em FRONTEND_URL para adicionar múltiplas origens
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "")
+allowed_origins = [url.strip() for url in FRONTEND_URL.split(",") if url.strip()]
+if allowed_origins:
+    CORS(app, supports_credentials=True, origins=allowed_origins)
 
 # Registrar blueprints
 app.register_blueprint(auth_bp, url_prefix='/api')


### PR DESCRIPTION
## Summary
- limit CORS to explicit origins from FRONTEND_URL env var
- document FRONTEND_URL usage for CORS configuration

## Testing
- `python -m py_compile src/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965226b190832c9b781d4542e50809