### PR TITLE
chore: configure nixpacks and health endpoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python src/main.py
+web: python src/main.py || python3 src/main.py
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,15 @@
+providers = ["python"]
+
+[phases.setup]
+# Instala apenas Python e pip
+nixPkgs = ["python312", "python312Packages.pip"]
+
+[phases.install]
+# Instala dependências do backend
+cmds = [
+  "pip install --no-cache-dir -r requirements.txt"
+]
+
+[start]
+# Sobe o Flask
+cmd = "python src/main.py"

--- a/src/main.py
+++ b/src/main.py
@@ -9,8 +9,6 @@ logging.basicConfig(level=logging.INFO)
 
 from flask import Flask, render_template, jsonify, send_from_directory
 from flask_cors import CORS
-from sqlalchemy import text
-from datetime import datetime
 
 # Importar modelos
 from src.db import db
@@ -102,7 +100,7 @@ def serve(path):
             return "index.html not found", 404
 
 # Healthcheck endpoint
-@app.route("/api/health")  # <-- ADICIONE ESTA LINHA
+@app.route("/api/health")
 @app.route("/health")
 def health():
     return jsonify({"status": "ok"}), 200
@@ -132,30 +130,6 @@ def api_index():
         }
     })
 
-@app.route('/api/health')
-def health_check():
-    """Health check endpoint para monitoramento.
-
-    A consulta ao banco pode falhar caso a infraestrutura ainda não
-    esteja totalmente disponível. Em vez de retornar 503 e fazer o
-    container ser considerado indisponível, retornamos sempre 200 e
-    informamos o status da conexão no payload.
-    """
-    try:
-        # Verificar conexão com banco de dados
-        db.session.execute(text('SELECT 1'))
-        db_status = 'connected'
-    except Exception as e:
-        db_status = f'error: {e}'
-
-    logging.info("Status da conexão com o banco: %s", db_status)
-
-    return jsonify({
-        'status': 'ok',
-        'timestamp': datetime.utcnow().isoformat(),
-        'version': '4.0',
-        'database': db_status
-    }), 200
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))


### PR DESCRIPTION
## Summary
- add nixpacks.toml for Nixpacks deployment
- allow Procfile to fall back to python3
- expose `/api/health` endpoint in Flask app

## Testing
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68966f83d688832cab55b754571b3d2a